### PR TITLE
AB-24: 修复 url.parse 废弃警告

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,12 @@
     "commander": "^15.0.0",
     "jsonc-parser": "^3.3.1",
     "lodash": "^4.18.1",
-    "mustache": "^4.2.0",
-    "urijs": "^1.19.11"
+    "mustache": "^4.2.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.21",
     "@types/mustache": "^4.2.0",
     "@types/node": "^22.19.1",
-    "@types/urijs": "^1.19.25",
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,6 @@ importers:
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
-      urijs:
-        specifier: ^1.19.11
-        version: 1.19.11
     devDependencies:
       '@types/lodash':
         specifier: ^4.17.21
@@ -44,9 +41,6 @@ importers:
       '@types/node':
         specifier: ^22.19.1
         version: 22.19.19
-      '@types/urijs':
-        specifier: ^1.19.25
-        version: 1.19.26
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.49.0
         version: 8.60.1(@typescript-eslint/parser@8.60.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -398,10 +392,6 @@ packages:
   '@types/responselike@1.0.3':
     resolution:
       { integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw== }
-
-  '@types/urijs@1.19.26':
-    resolution:
-      { integrity: sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg== }
 
   '@typescript-eslint/eslint-plugin@8.60.1':
     resolution:
@@ -1953,11 +1943,6 @@ packages:
       { integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg== }
     engines: { node: '>= 0.6' }
 
-  mime-db@1.54.0:
-    resolution:
-      { integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ== }
-    engines: { node: '>= 0.6' }
-
   mime-lookup@0.0.2:
     resolution:
       { integrity: sha512-6384dzMc9tsk9wBt/W9jG1hWEUPk7oPwj0ExsJCAI9peB11GbWniOWg0O/Uf8vZbvK8bkPKPtaVDtZI0FWlwbg== }
@@ -2603,14 +2588,14 @@ packages:
       { integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw== }
     engines: { node: '>=4' }
 
-  string.prototype.trim@1.2.10:
+  string.prototype.trim@1.2.11:
     resolution:
-      { integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA== }
+      { integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w== }
     engines: { node: '>= 0.4' }
 
-  string.prototype.trimend@1.0.9:
+  string.prototype.trimend@1.0.10:
     resolution:
-      { integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ== }
+      { integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw== }
     engines: { node: '>= 0.4' }
 
   string.prototype.trimstart@1.0.8:
@@ -2983,9 +2968,9 @@ packages:
     resolution:
       { integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ== }
 
-  which-typed-array@1.1.21:
+  which-typed-array@1.1.22:
     resolution:
-      { integrity: sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw== }
+      { integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw== }
     engines: { node: '>= 0.4' }
 
   which@1.3.1:
@@ -3278,8 +3263,6 @@ snapshots:
     dependencies:
       '@types/node': 22.19.19
     optional: true
-
-  '@types/urijs@1.19.26': {}
 
   '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -3846,15 +3829,15 @@ snapshots:
       safe-regex-test: 1.1.0
       set-proto: 1.0.0
       stop-iteration-iterator: 1.1.0
-      string.prototype.trim: 1.2.10
-      string.prototype.trimend: 1.0.9
+      string.prototype.trim: 1.2.11
+      string.prototype.trimend: 1.0.10
       string.prototype.trimstart: 1.0.8
       typed-array-buffer: 1.0.3
       typed-array-byte-length: 1.0.3
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.8
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.21
+      which-typed-array: 1.1.22
 
   es-define-property@1.0.1: {}
 
@@ -4198,7 +4181,7 @@ snapshots:
       json-schema-compatibility: 1.1.0
       jsonpath: 1.3.0
       lodash: 4.18.1
-      mime-db: 1.54.0
+      mime-db: 1.52.0
       mime-lookup: 0.0.2
       traverse: 0.6.11
       urijs: 1.19.11
@@ -4427,7 +4410,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.21
+      which-typed-array: 1.1.22
 
   is-typedarray@1.0.0: {}
 
@@ -4702,9 +4685,6 @@ snapshots:
   methods@1.1.2: {}
 
   mime-db@1.52.0: {}
-
-  mime-db@1.54.0:
-    optional: true
 
   mime-lookup@0.0.2:
     optional: true
@@ -5314,7 +5294,7 @@ snapshots:
       strip-ansi: 4.0.0
     optional: true
 
-  string.prototype.trim@1.2.10:
+  string.prototype.trim@1.2.11:
     dependencies:
       call-bind: 1.0.9
       call-bound: 1.0.4
@@ -5323,8 +5303,9 @@ snapshots:
       es-abstract: 1.24.2
       es-object-atoms: 1.1.2
       has-property-descriptors: 1.0.2
+      safe-regex-test: 1.1.0
 
-  string.prototype.trimend@1.0.9:
+  string.prototype.trimend@1.0.10:
     dependencies:
       call-bind: 1.0.9
       call-bound: 1.0.4
@@ -5460,7 +5441,7 @@ snapshots:
     dependencies:
       gopd: 1.2.0
       typedarray.prototype.slice: 1.0.5
-      which-typed-array: 1.1.21
+      which-typed-array: 1.1.22
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -5655,7 +5636,7 @@ snapshots:
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.21
+      which-typed-array: 1.1.22
 
   which-collection@1.0.2:
     dependencies:
@@ -5667,7 +5648,7 @@ snapshots:
   which-module@2.0.1:
     optional: true
 
-  which-typed-array@1.1.21:
+  which-typed-array@1.1.22:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.9

--- a/src/CodeGen.ts
+++ b/src/CodeGen.ts
@@ -5,9 +5,7 @@ import SwaggerParser from '@apidevtools/swagger-parser'
 import { OpenAPIV2, IJsonSchema } from 'openapi-types'
 import Mustache from 'mustache'
 import _ from 'lodash'
-import ApiSpecConverter from 'api-spec-converter'
 import axios from 'axios'
-import URI from 'urijs'
 
 export interface GenConfig {
   /**
@@ -208,24 +206,29 @@ export class CodeGen {
   }
 
   private async fetchJsonText(pathOrUrl: string) {
-    try {
-      if (fs.existsSync(pathOrUrl)) {
-        return fs.readFileSync(pathOrUrl, { encoding: 'utf-8' })
-      }
-    } catch (e) {}
-
-    const uri = new URI(pathOrUrl)
-    if (uri.is('absolute')) {
-      const resp = await axios.get(this.#config.docUrl, { responseType: 'text' })
-      const text = resp.data
-      if (typeof text === 'object') {
-        return JSON.stringify(text, null, 2)
-      }
-      return text
-    } else if (uri.is('relative')) {
-      return fs.readFileSync(pathOrUrl, { encoding: 'utf-8' })
-    } else {
+    const text = pathOrUrl.trim()
+    if (text.startsWith('{') || text.startsWith('[')) {
       return pathOrUrl
+    }
+
+    if (this.isHttpUrl(pathOrUrl)) {
+      const resp = await axios.get(pathOrUrl, { responseType: 'text' })
+      const data = resp.data
+      if (typeof data === 'object') {
+        return JSON.stringify(data, null, 2)
+      }
+      return data
+    }
+
+    return fs.readFileSync(pathOrUrl, { encoding: 'utf-8' })
+  }
+
+  private isHttpUrl(value: string) {
+    try {
+      const url = new URL(value)
+      return url.protocol === 'http:' || url.protocol === 'https:'
+    } catch (error) {
+      return false
     }
   }
 
@@ -253,6 +256,7 @@ export class CodeGen {
       fs.writeFileSync(outputPath, JSON.stringify(apiDocsJson, undefined, 2), fileOptions)
 
       if (docVersion.startsWith('3.')) {
+        const ApiSpecConverter = require('api-spec-converter')
         const converted = await ApiSpecConverter.convert({
           from: 'openapi_3',
           to: 'swagger_2',

--- a/src/typings/swagger2openapi.d.ts
+++ b/src/typings/swagger2openapi.d.ts
@@ -1,3 +1,0 @@
-declare module 'swagger2openapi' {
-  export function convertObj(swagger: any, options: any, callback?: any): any
-}


### PR DESCRIPTION
## 变更
- 移除直接依赖 URI.js 的文档地址判断，改用 WHATWG URL 判断 HTTP/HTTPS 文档地址
- 延迟加载 api-spec-converter，避免普通 Swagger 2 生成流程初始化旧 swagger2openapi/ajv 依赖并触发 DEP0169
- 移除未使用的 swagger2openapi 类型声明

## 验证
- NODE_OPTIONS=--trace-deprecation pnpm test
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm pack --pack-destination /tmp
- pnpm install --frozen-lockfile
- git diff --check

Closes AB-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)