### PR TITLE
AB-24: 移除 OpenAPI 3 url.parse 警告

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "homepage": "https://github.com/arbing/swagger-to-ts#readme",
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
-    "api-spec-converter": "^2.12.0",
     "axios": "^1.17.0",
     "chalk": "^4.1.2",
     "commander": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,6 @@ importers:
       '@apidevtools/swagger-parser':
         specifier: ^12.1.0
         version: 12.1.0(openapi-types@12.1.3)
-      api-spec-converter:
-        specifier: ^2.12.0
-        version: 2.12.0
       axios:
         specifier: ^1.17.0
         version: 1.17.0
@@ -93,10 +90,6 @@ packages:
     peerDependencies:
       openapi-types: '>=7'
 
-  '@cloudflare/json-schema-walker@0.1.1':
-    resolution:
-      { integrity: sha512-P3n0hEgk1m6uKWgL4Yb1owzXVG4pM70G4kRnDQxZXiVvfCRtaqiHu+ZRiRPzmwGBiLTO1LWc2yR1M8oz0YkXww== }
-
   '@cspotcode/source-map-support@0.8.1':
     resolution:
       { integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw== }
@@ -165,31 +158,12 @@ packages:
     resolution:
       { integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ== }
 
-  '@jsep-plugin/assignment@1.3.0':
-    resolution:
-      { integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ== }
-    engines: { node: '>= 10.16.0' }
-    peerDependencies:
-      jsep: ^0.4.0||^1.0.0
-
-  '@jsep-plugin/regex@1.0.4':
-    resolution:
-      { integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg== }
-    engines: { node: '>= 10.16.0' }
-    peerDependencies:
-      jsep: ^0.4.0||^1.0.0
-
   '@napi-rs/wasm-runtime@1.1.4':
     resolution:
       { integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow== }
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@noble/hashes@1.8.0':
-    resolution:
-      { integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A== }
-    engines: { node: ^14.21.3 || >=16 }
 
   '@nodelib/fs.scandir@2.1.5':
     resolution:
@@ -209,10 +183,6 @@ packages:
   '@oxc-project/types@0.133.0':
     resolution:
       { integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA== }
-
-  '@paralleldrive/cuid2@2.3.1':
-    resolution:
-      { integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw== }
 
   '@pkgr/core@0.3.6':
     resolution:
@@ -373,10 +343,6 @@ packages:
     resolution:
       { integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA== }
 
-  '@types/keyv@3.1.4':
-    resolution:
-      { integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg== }
-
   '@types/lodash@4.17.24':
     resolution:
       { integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ== }
@@ -388,10 +354,6 @@ packages:
   '@types/node@22.19.19':
     resolution:
       { integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew== }
-
-  '@types/responselike@1.0.3':
-    resolution:
-      { integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw== }
 
   '@typescript-eslint/eslint-plugin@8.60.1':
     resolution:
@@ -502,15 +464,6 @@ packages:
     resolution:
       { integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg== }
 
-  JSONSelect@0.4.0:
-    resolution:
-      { integrity: sha512-VRLR3Su35MH+XV2lrvh9O7qWoug/TUyj9tLDjn9rtpUCNnILLrHjgd/tB0KrhugCxUpj3UqoLqfYb3fLJdIQQQ== }
-    engines: { node: '>=0.4.7' }
-
-  abbrev@1.1.1:
-    resolution:
-      { integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q== }
-
   acorn-jsx@5.3.2:
     resolution:
       { integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ== }
@@ -542,10 +495,6 @@ packages:
       ajv:
         optional: true
 
-  ajv@5.5.2:
-    resolution:
-      { integrity: sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw== }
-
   ajv@6.15.0:
     resolution:
       { integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw== }
@@ -553,16 +502,6 @@ packages:
   ajv@8.20.0:
     resolution:
       { integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA== }
-
-  ansi-regex@2.1.1:
-    resolution:
-      { integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA== }
-    engines: { node: '>=0.10.0' }
-
-  ansi-regex@3.0.1:
-    resolution:
-      { integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw== }
-    engines: { node: '>=4' }
 
   ansi-regex@5.0.1:
     resolution:
@@ -574,82 +513,22 @@ packages:
       { integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg== }
     engines: { node: '>=8' }
 
-  api-spec-converter@2.12.0:
-    resolution:
-      { integrity: sha512-awKL523vwkmyf3rTzmW/lopAbHRhqJw84IThAovtoQ60u6TblCoGIEhhpDDfb9WycncU2aDrVfqf9LQC5lcUTQ== }
-    engines: { node: '>=6.0.0' }
-    hasBin: true
-
-  apib-include-directive@0.1.0:
-    resolution:
-      { integrity: sha512-7m5LKbmFGeJogORhkLOCQjcEuGrRcVLG32nHbTAAYjvZ3cSV1XaxU8LBXIvx0PyLYL4mE/gc0Nu0Y7odQmAU1Q== }
-
-  apib2swagger@1.17.1:
-    resolution:
-      { integrity: sha512-2ednp+ckytSEOvX3CaUcHYC01wmzzfy970T22EJiBzcl4rj5p5UvUxXxHh6gCSCmDTkqKdiIFCLhoIJGynN8CQ== }
-    hasBin: true
-
   arg@4.1.3:
     resolution:
       { integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA== }
 
-  argparse@1.0.10:
-    resolution:
-      { integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg== }
-
   argparse@2.0.1:
     resolution:
       { integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q== }
-
-  array-buffer-byte-length@1.0.2:
-    resolution:
-      { integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw== }
-    engines: { node: '>= 0.4' }
-
-  arraybuffer.prototype.slice@1.0.4:
-    resolution:
-      { integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ== }
-    engines: { node: '>= 0.4' }
-
-  asap@2.0.6:
-    resolution:
-      { integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA== }
-
-  asn1@0.2.6:
-    resolution:
-      { integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ== }
-
-  assert-plus@1.0.0:
-    resolution:
-      { integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw== }
-    engines: { node: '>=0.8' }
 
   assertion-error@2.0.1:
     resolution:
       { integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA== }
     engines: { node: '>=12' }
 
-  async-function@1.0.0:
-    resolution:
-      { integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA== }
-    engines: { node: '>= 0.4' }
-
   asynckit@0.4.0:
     resolution:
       { integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q== }
-
-  available-typed-arrays@1.0.7:
-    resolution:
-      { integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ== }
-    engines: { node: '>= 0.4' }
-
-  aws-sign2@0.7.0:
-    resolution:
-      { integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA== }
-
-  aws4@1.13.2:
-    resolution:
-      { integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw== }
 
   axios@1.17.0:
     resolution:
@@ -663,14 +542,6 @@ packages:
     resolution:
       { integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA== }
     engines: { node: 18 || 20 || >=22 }
-
-  bcrypt-pbkdf@1.0.2:
-    resolution:
-      { integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w== }
-
-  bluebird@3.7.2:
-    resolution:
-      { integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg== }
 
   brace-expansion@1.1.15:
     resolution:
@@ -686,16 +557,6 @@ packages:
       { integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ== }
     engines: { node: '>= 0.4' }
 
-  call-bind@1.0.9:
-    resolution:
-      { integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ== }
-    engines: { node: '>= 0.4' }
-
-  call-bound@1.0.4:
-    resolution:
-      { integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg== }
-    engines: { node: '>= 0.4' }
-
   call-me-maybe@1.0.2:
     resolution:
       { integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ== }
@@ -704,15 +565,6 @@ packages:
     resolution:
       { integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ== }
     engines: { node: '>=6' }
-
-  camelcase@4.1.0:
-    resolution:
-      { integrity: sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw== }
-    engines: { node: '>=4' }
-
-  caseless@0.12.0:
-    resolution:
-      { integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw== }
 
   chai@6.2.2:
     resolution:
@@ -724,25 +576,6 @@ packages:
       { integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA== }
     engines: { node: '>=10' }
 
-  cjson@0.2.1:
-    resolution:
-      { integrity: sha512-Yche6o3bxUlXx6vGDjDwcWU3cSLGyRxGQpDk/FNHKDt02c715rBvuPLBfP1/+U+quWm/lU4F8N5sZbRCxpsrIg== }
-    engines: { node: '>= 0.3.0' }
-
-  cliui@3.2.0:
-    resolution:
-      { integrity: sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w== }
-
-  co@4.6.0:
-    resolution:
-      { integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ== }
-    engines: { iojs: '>= 1.0.0', node: '>= 0.12.0' }
-
-  code-point-at@1.1.0:
-    resolution:
-      { integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA== }
-    engines: { node: '>=0.10.0' }
-
   color-convert@2.0.1:
     resolution:
       { integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ== }
@@ -751,11 +584,6 @@ packages:
   color-name@1.1.4:
     resolution:
       { integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA== }
-
-  colors@0.5.1:
-    resolution:
-      { integrity: sha512-XjsuUwpDeY98+yz959OlUK6m7mLBM+1MEG5oaenfuQnNnrQk1WvtcvFgN3FNDP3f2NmZ211t0mNEfSEN1h0eIg== }
-    engines: { node: '>=0.1.90' }
 
   combined-stream@1.0.8:
     resolution:
@@ -767,27 +595,6 @@ packages:
       { integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg== }
     engines: { node: '>=22.12.0' }
 
-  commander@2.20.3:
-    resolution:
-      { integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ== }
-
-  commander@4.1.1:
-    resolution:
-      { integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA== }
-    engines: { node: '>= 6' }
-
-  common-prefix@1.1.0:
-    resolution:
-      { integrity: sha512-9HAWgTP6U7K4G94u3J/oETIczTkzqZGn/cVFHDKVh/iFtZPBxuJ/qT+8Q5Np1XSXMZsRgnrpes7SrWOTJxFtaw== }
-
-  component-emitter@1.3.1:
-    resolution:
-      { integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ== }
-
-  composite-error@0.1.1:
-    resolution:
-      { integrity: sha512-uKfFK2AO3V4YrzwnWYs0zO6jhfLScr30RoQ6iqG62iWXkp0G5w/Fx8W3y9ax5nwrlKzvTQzk1K6ODvChkwhCFA== }
-
   concat-map@0.0.1:
     resolution:
       { integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg== }
@@ -796,64 +603,14 @@ packages:
     resolution:
       { integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg== }
 
-  cookiejar@2.1.4:
-    resolution:
-      { integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw== }
-
-  core-js@2.6.12:
-    resolution:
-      { integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ== }
-    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
-
-  core-util-is@1.0.2:
-    resolution:
-      { integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ== }
-
-  core-util-is@1.0.3:
-    resolution:
-      { integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ== }
-
   create-require@1.1.1:
     resolution:
       { integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ== }
-
-  cross-spawn@5.1.0:
-    resolution:
-      { integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A== }
 
   cross-spawn@7.0.6:
     resolution:
       { integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA== }
     engines: { node: '>= 8' }
-
-  dashdash@1.14.1:
-    resolution:
-      { integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g== }
-    engines: { node: '>=0.10' }
-
-  data-view-buffer@1.0.2:
-    resolution:
-      { integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ== }
-    engines: { node: '>= 0.4' }
-
-  data-view-byte-length@1.0.2:
-    resolution:
-      { integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ== }
-    engines: { node: '>= 0.4' }
-
-  data-view-byte-offset@1.0.1:
-    resolution:
-      { integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ== }
-    engines: { node: '>= 0.4' }
-
-  debug@3.2.7:
-    resolution:
-      { integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ== }
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.3:
     resolution:
@@ -865,28 +622,9 @@ packages:
       supports-color:
         optional: true
 
-  decamelize@1.2.0:
-    resolution:
-      { integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA== }
-    engines: { node: '>=0.10.0' }
-
   deep-is@0.1.4:
     resolution:
       { integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ== }
-
-  deep-sort-object@1.0.2:
-    resolution:
-      { integrity: sha512-Ko2XVMhRhz5Mxyb+QhLX13SHgcK1vuxc6XEfOyTMlbRbv7bhSmMqUw4ywqRwKgV25W+FDIaZjPWQrdblHCTwdA== }
-
-  define-data-property@1.1.4:
-    resolution:
-      { integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A== }
-    engines: { node: '>= 0.4' }
-
-  define-properties@1.2.1:
-    resolution:
-      { integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg== }
-    engines: { node: '>= 0.4' }
 
   delayed-stream@1.0.0:
     resolution:
@@ -898,10 +636,6 @@ packages:
       { integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ== }
     engines: { node: '>=8' }
 
-  dezalgo@1.0.4:
-    resolution:
-      { integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig== }
-
   diff@4.0.4:
     resolution:
       { integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ== }
@@ -912,43 +646,9 @@ packages:
       { integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w== }
     engines: { node: '>=6.0.0' }
 
-  drafter.js@2.6.7:
-    resolution:
-      { integrity: sha512-B6/nqEr3B9N8B4eySiPVXnFvI9Fh62Xl6GBQVncoh1aDcnYxSME5S8nZEERd4LjSYLzZchqnEC0F4oaXhSRJtA== }
-    engines: { node: '>= 0.12' }
-
   dunder-proto@1.0.1:
     resolution:
       { integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A== }
-    engines: { node: '>= 0.4' }
-
-  duplexify@3.7.1:
-    resolution:
-      { integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g== }
-
-  ebnf-parser@0.1.10:
-    resolution:
-      { integrity: sha512-urvSxVQ6XJcoTpc+/x2pWhhuOX4aljCNQpwzw+ifZvV1andZkAmiJc3Rq1oGEAQmcjiLceyMXOy1l8ms8qs2fQ== }
-
-  ecc-jsbn@0.1.2:
-    resolution:
-      { integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw== }
-
-  encoding@0.1.13:
-    resolution:
-      { integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A== }
-
-  end-of-stream@1.4.5:
-    resolution:
-      { integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg== }
-
-  error-ex@1.3.4:
-    resolution:
-      { integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ== }
-
-  es-abstract@1.24.2:
-    resolution:
-      { integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg== }
     engines: { node: '>= 0.4' }
 
   es-define-property@1.0.1:
@@ -975,41 +675,10 @@ packages:
       { integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA== }
     engines: { node: '>= 0.4' }
 
-  es-to-primitive@1.3.0:
-    resolution:
-      { integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g== }
-    engines: { node: '>= 0.4' }
-
-  es6-promise@3.3.1:
-    resolution:
-      { integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg== }
-
-  es6-promise@4.2.8:
-    resolution:
-      { integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w== }
-
   escape-string-regexp@4.0.0:
     resolution:
       { integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA== }
     engines: { node: '>=10' }
-
-  escodegen@0.0.21:
-    resolution:
-      { integrity: sha512-BQL5g+BqyrM5HRAKt4Q4YuH9CqiEcIHWSJ8fg2PRNkGkXn/LgzeDCZzDDSX4UiljSAHgXaHgOZREQ2xOigbLzA== }
-    engines: { node: '>=0.4.0' }
-    hasBin: true
-
-  escodegen@0.0.28:
-    resolution:
-      { integrity: sha512-6ioQhg16lFs5c7XJlJFXIDxBjO4yRvXC9yK6dLNNGuhI3a/fJukHanPF6qtpjGDgAFzI8Wuq3PSIarWmaOq/5A== }
-    engines: { node: '>=0.4.0' }
-    hasBin: true
-
-  escodegen@2.1.0:
-    resolution:
-      { integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w== }
-    engines: { node: '>=6.0' }
-    hasBin: true
 
   eslint-config-prettier@10.1.8:
     resolution:
@@ -1060,30 +729,6 @@ packages:
       { integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ== }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
-  esprima@1.0.4:
-    resolution:
-      { integrity: sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA== }
-    engines: { node: '>=0.4.0' }
-    hasBin: true
-
-  esprima@1.2.2:
-    resolution:
-      { integrity: sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A== }
-    engines: { node: '>=0.4.0' }
-    hasBin: true
-
-  esprima@1.2.5:
-    resolution:
-      { integrity: sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ== }
-    engines: { node: '>=0.4.0' }
-    hasBin: true
-
-  esprima@4.0.1:
-    resolution:
-      { integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A== }
-    engines: { node: '>=4' }
-    hasBin: true
-
   esquery@1.7.0:
     resolution:
       { integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g== }
@@ -1093,16 +738,6 @@ packages:
     resolution:
       { integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag== }
     engines: { node: '>=4.0' }
-
-  estraverse@0.0.4:
-    resolution:
-      { integrity: sha512-21DfBCsFJGb3HZr0vEBH1Wk1tGSbbzA8I/xtSSoy/pRtupHv0OgBmObcNGXM3ec6/pOXTOOUYY9/5bfluzz0sw== }
-    engines: { node: '>=0.4.0' }
-
-  estraverse@1.3.2:
-    resolution:
-      { integrity: sha512-OkbCPVUu8D9tbsLcUR+CKFRBbhZlogmkbWaP3BPERlkqzWL5Q6IdTz6eUk+b5cid2MTaCqJb2nNRGoJ8TpfPrg== }
-    engines: { node: '>=0.4.0' }
 
   estraverse@5.3.0:
     resolution:
@@ -1118,32 +753,10 @@ packages:
       { integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g== }
     engines: { node: '>=0.10.0' }
 
-  execa@0.7.0:
-    resolution:
-      { integrity: sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw== }
-    engines: { node: '>=4' }
-
   expect-type@1.3.0:
     resolution:
       { integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA== }
     engines: { node: '>=12.0.0' }
-
-  extend@3.0.2:
-    resolution:
-      { integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g== }
-
-  extsprintf@1.3.0:
-    resolution:
-      { integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g== }
-    engines: { '0': node >=0.6.0 }
-
-  faker@4.1.0:
-    resolution:
-      { integrity: sha512-ILKg69P6y/D8/wSmDXw35Ly0re8QzQ8pMfBCflsGiZG2ZjMUNLYNexA6lz5pkmJlepVdsiDFUxYAzPQ9/+iGLA== }
-
-  fast-deep-equal@1.1.0:
-    resolution:
-      { integrity: sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw== }
 
   fast-deep-equal@3.1.3:
     resolution:
@@ -1160,10 +773,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution:
       { integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw== }
-
-  fast-safe-stringify@2.1.1:
-    resolution:
-      { integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA== }
 
   fast-uri@3.1.2:
     resolution:
@@ -1187,11 +796,6 @@ packages:
     resolution:
       { integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg== }
     engines: { node: ^10.12.0 || >=12.0.0 }
-
-  find-up@2.1.0:
-    resolution:
-      { integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ== }
-    engines: { node: '>=4' }
 
   find-up@5.0.0:
     resolution:
@@ -1217,32 +821,10 @@ packages:
       debug:
         optional: true
 
-  for-each@0.3.5:
-    resolution:
-      { integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg== }
-    engines: { node: '>= 0.4' }
-
-  forever-agent@0.6.1:
-    resolution:
-      { integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw== }
-
-  form-data@2.3.3:
-    resolution:
-      { integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ== }
-    engines: { node: '>= 0.12' }
-
   form-data@4.0.5:
     resolution:
       { integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w== }
     engines: { node: '>= 6' }
-
-  format-util@1.0.5:
-    resolution:
-      { integrity: sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg== }
-
-  formidable@2.1.5:
-    resolution:
-      { integrity: sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q== }
 
   fs.realpath@1.0.0:
     resolution:
@@ -1258,29 +840,6 @@ packages:
     resolution:
       { integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA== }
 
-  function.prototype.name@1.1.8:
-    resolution:
-      { integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q== }
-    engines: { node: '>= 0.4' }
-
-  functions-have-names@1.2.3:
-    resolution:
-      { integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ== }
-
-  generate-schema@2.6.0:
-    resolution:
-      { integrity: sha512-EUBKfJNzT8f91xUk5X5gKtnbdejZeE065UAJ3BCzE8VEbvwKI9Pm5jaWmqVeK1MYc1g5weAVFDTSJzN7ymtTqA== }
-    hasBin: true
-
-  generator-function@2.0.1:
-    resolution:
-      { integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g== }
-    engines: { node: '>= 0.4' }
-
-  get-caller-file@1.0.3:
-    resolution:
-      { integrity: sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w== }
-
   get-intrinsic@1.3.0:
     resolution:
       { integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ== }
@@ -1290,20 +849,6 @@ packages:
     resolution:
       { integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g== }
     engines: { node: '>= 0.4' }
-
-  get-stream@3.0.0:
-    resolution:
-      { integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ== }
-    engines: { node: '>=4' }
-
-  get-symbol-description@1.1.0:
-    resolution:
-      { integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg== }
-    engines: { node: '>= 0.4' }
-
-  getpass@0.1.7:
-    resolution:
-      { integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng== }
 
   glob-parent@6.0.2:
     resolution:
@@ -1320,66 +865,19 @@ packages:
       { integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ== }
     engines: { node: '>=8' }
 
-  globalthis@1.0.4:
-    resolution:
-      { integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ== }
-    engines: { node: '>= 0.4' }
-
-  google-discovery-to-swagger@2.1.0:
-    resolution:
-      { integrity: sha512-MI1gfmWPkuXCp6yH+9rfd8ZG8R1R5OIyY4WlKDTqr2+ere1gt2Ne4DSEu8HM7NkwKpuVCE5TrTRAPfm3ownMUQ== }
-
   gopd@1.2.0:
     resolution:
       { integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg== }
     engines: { node: '>= 0.4' }
 
-  got@2.4.0:
-    resolution:
-      { integrity: sha512-FZ9t9NbPnhVEVPxjoRJuZUi6qmVlzBfSqS+FCU7npZLrTllzFeUAT1D79oz2n44qYM/Moz6eBFB9yzyKgZmHXg== }
-    engines: { node: '>=0.10.0' }
-
-  graceful-fs@4.2.11:
-    resolution:
-      { integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ== }
-
   graphemer@1.4.0:
     resolution:
       { integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag== }
-
-  graphlib@2.1.8:
-    resolution:
-      { integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A== }
-
-  har-schema@2.0.0:
-    resolution:
-      { integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q== }
-    engines: { node: '>=4' }
-
-  har-validator@5.1.5:
-    resolution:
-      { integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w== }
-    engines: { node: '>=6' }
-    deprecated: this library is no longer supported
-
-  has-bigints@1.1.0:
-    resolution:
-      { integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg== }
-    engines: { node: '>= 0.4' }
 
   has-flag@4.0.0:
     resolution:
       { integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ== }
     engines: { node: '>=8' }
-
-  has-property-descriptors@1.0.2:
-    resolution:
-      { integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg== }
-
-  has-proto@1.2.0:
-    resolution:
-      { integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ== }
-    engines: { node: '>= 0.4' }
 
   has-symbols@1.1.0:
     resolution:
@@ -1396,28 +894,10 @@ packages:
       { integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A== }
     engines: { node: '>= 0.4' }
 
-  hosted-git-info@2.8.9:
-    resolution:
-      { integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw== }
-
-  http-signature@1.2.0:
-    resolution:
-      { integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ== }
-    engines: { node: '>=0.8', npm: '>=1.3.7' }
-
-  http-status-codes@1.4.0:
-    resolution:
-      { integrity: sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ== }
-
   https-proxy-agent@5.0.1:
     resolution:
       { integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA== }
     engines: { node: '>= 6' }
-
-  iconv-lite@0.6.3:
-    resolution:
-      { integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw== }
-    engines: { node: '>=0.10.0' }
 
   ignore@5.3.2:
     resolution:
@@ -1439,10 +919,6 @@ packages:
       { integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA== }
     engines: { node: '>=0.8.19' }
 
-  infinity-agent@1.0.2:
-    resolution:
-      { integrity: sha512-QVet+evQIBtn+Cd+8nL1M8pOmBTzShfsQCgaXJoA+dV0UtKMnTPnkkkgXkM5eM+oC1qTv9UDew/LL9ElxiA/MQ== }
-
   inflight@1.0.6:
     resolution:
       { integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA== }
@@ -1452,275 +928,33 @@ packages:
     resolution:
       { integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ== }
 
-  internal-slot@1.1.0:
-    resolution:
-      { integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw== }
-    engines: { node: '>= 0.4' }
-
-  invert-kv@1.0.0:
-    resolution:
-      { integrity: sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ== }
-    engines: { node: '>=0.10.0' }
-
-  is-array-buffer@3.0.5:
-    resolution:
-      { integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A== }
-    engines: { node: '>= 0.4' }
-
-  is-arrayish@0.2.1:
-    resolution:
-      { integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg== }
-
-  is-async-function@2.1.1:
-    resolution:
-      { integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ== }
-    engines: { node: '>= 0.4' }
-
-  is-bigint@1.1.0:
-    resolution:
-      { integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ== }
-    engines: { node: '>= 0.4' }
-
-  is-boolean-object@1.2.2:
-    resolution:
-      { integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A== }
-    engines: { node: '>= 0.4' }
-
-  is-callable@1.2.7:
-    resolution:
-      { integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA== }
-    engines: { node: '>= 0.4' }
-
-  is-core-module@2.16.2:
-    resolution:
-      { integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA== }
-    engines: { node: '>= 0.4' }
-
-  is-data-view@1.0.2:
-    resolution:
-      { integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw== }
-    engines: { node: '>= 0.4' }
-
-  is-date-object@1.1.0:
-    resolution:
-      { integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg== }
-    engines: { node: '>= 0.4' }
-
   is-extglob@2.1.1:
     resolution:
       { integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ== }
     engines: { node: '>=0.10.0' }
-
-  is-finalizationregistry@1.1.1:
-    resolution:
-      { integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg== }
-    engines: { node: '>= 0.4' }
-
-  is-fullwidth-code-point@1.0.0:
-    resolution:
-      { integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw== }
-    engines: { node: '>=0.10.0' }
-
-  is-fullwidth-code-point@2.0.0:
-    resolution:
-      { integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w== }
-    engines: { node: '>=4' }
-
-  is-generator-function@1.1.2:
-    resolution:
-      { integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA== }
-    engines: { node: '>= 0.4' }
 
   is-glob@4.0.3:
     resolution:
       { integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg== }
     engines: { node: '>=0.10.0' }
 
-  is-map@2.0.3:
-    resolution:
-      { integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw== }
-    engines: { node: '>= 0.4' }
-
-  is-negative-zero@2.0.3:
-    resolution:
-      { integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw== }
-    engines: { node: '>= 0.4' }
-
-  is-number-object@1.1.1:
-    resolution:
-      { integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw== }
-    engines: { node: '>= 0.4' }
-
   is-path-inside@3.0.3:
     resolution:
       { integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ== }
     engines: { node: '>=8' }
 
-  is-plain-object@2.0.4:
-    resolution:
-      { integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og== }
-    engines: { node: '>=0.10.0' }
-
-  is-regex@1.2.1:
-    resolution:
-      { integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g== }
-    engines: { node: '>= 0.4' }
-
-  is-set@2.0.3:
-    resolution:
-      { integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg== }
-    engines: { node: '>= 0.4' }
-
-  is-shared-array-buffer@1.0.4:
-    resolution:
-      { integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A== }
-    engines: { node: '>= 0.4' }
-
-  is-stream@1.1.0:
-    resolution:
-      { integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ== }
-    engines: { node: '>=0.10.0' }
-
-  is-string@1.1.1:
-    resolution:
-      { integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA== }
-    engines: { node: '>= 0.4' }
-
-  is-symbol@1.1.1:
-    resolution:
-      { integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w== }
-    engines: { node: '>= 0.4' }
-
-  is-typed-array@1.1.15:
-    resolution:
-      { integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ== }
-    engines: { node: '>= 0.4' }
-
-  is-typedarray@1.0.0:
-    resolution:
-      { integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA== }
-
-  is-weakmap@2.0.2:
-    resolution:
-      { integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w== }
-    engines: { node: '>= 0.4' }
-
-  is-weakref@1.1.1:
-    resolution:
-      { integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew== }
-    engines: { node: '>= 0.4' }
-
-  is-weakset@2.0.4:
-    resolution:
-      { integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ== }
-    engines: { node: '>= 0.4' }
-
-  isarray@0.0.1:
-    resolution:
-      { integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ== }
-
-  isarray@1.0.0:
-    resolution:
-      { integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ== }
-
-  isarray@2.0.5:
-    resolution:
-      { integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw== }
-
   isexe@2.0.0:
     resolution:
       { integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw== }
-
-  isobject@3.0.1:
-    resolution:
-      { integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg== }
-    engines: { node: '>=0.10.0' }
-
-  isstream@0.1.2:
-    resolution:
-      { integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g== }
-
-  jgexml@0.3.9:
-    resolution:
-      { integrity: sha512-OiucENxrgrQ0HgBhb0LewMeubJsOdKwoauSJsSk0eXBnXupW+RmeGvAcC5agdFw+V5f+OAIwmgvutOQAwnPZfw== }
-
-  jison-lex@0.2.1:
-    resolution:
-      { integrity: sha512-WCNVPRxaTWdhwJAIrBsgkGT9n6H1yNR9Lfof5LUHaMul24ySrJ1SXbVPszZfs57jwXvASLWBpd0xpFEW2oIuVA== }
-    engines: { node: '>=0.4' }
-    hasBin: true
-
-  jison@0.4.13:
-    resolution:
-      { integrity: sha512-H/r8t7Ft4zuGyQZUI0Ai2rh6WAHJoAGG1kJhI1MGKfgFO2/mqnxr9JmYMU/LcC95+DxO2bGqVXv5LDRiv06eRA== }
-    engines: { node: '>=0.4' }
-    hasBin: true
-
-  jju@1.2.1:
-    resolution:
-      { integrity: sha512-GpUVIrMsjtyZ3YDSIM3w3UGDZKjeVmIv9mW+KYnxDhovh9GnPjucVp13mdxiZmcZxjbenRAFs4gWEQIVXXvoYw== }
-
-  js-base64@2.6.4:
-    resolution:
-      { integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ== }
-
-  js-yaml@3.14.2:
-    resolution:
-      { integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg== }
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution:
       { integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw== }
     hasBin: true
 
-  jsbn@0.1.1:
-    resolution:
-      { integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg== }
-
-  jsep@1.4.0:
-    resolution:
-      { integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw== }
-    engines: { node: '>= 10.16.0' }
-
   json-buffer@3.0.1:
     resolution:
       { integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ== }
-
-  json-refs@3.0.15:
-    resolution:
-      { integrity: sha512-0vOQd9eLNBL18EGl5yYaO44GhixmImes2wiYn9Z3sag3QnehWrYWlB9AFtMxCL2Bj3fyxgDYkxGFEU/chlYssw== }
-    engines: { node: '>=0.8' }
-    hasBin: true
-
-  json-schema-compatibility@1.1.0:
-    resolution:
-      { integrity: sha512-/ZDuZvZFAi9XnuVQHdUlUvHSxN/ksFn8KDVHiLUJWumpRagccER/tRNY1GKNMguYdJCjaTZweTjf1faugxFfjw== }
-    engines: { node: '>= 0.8.0' }
-
-  json-schema-faker@0.5.9:
-    resolution:
-      { integrity: sha512-fNKLHgDvfGNNTX1zqIjqFMJjCLzJ2kvnJ831x4aqkAoeE4jE2TxvpJdhOnk3JU3s42vFzmXvkpbYzH5H3ncAzg== }
-    hasBin: true
-
-  json-schema-ref-parser@3.3.1:
-    resolution:
-      { integrity: sha512-stQTMhec2R/p2L9dH4XXRlpNCP0mY8QrLd/9Kl+8SHJQmwHtE1nDfXH4wbsSM+GkJMl8t92yZbI0OIol432CIQ== }
-    deprecated: Please switch to @apidevtools/json-schema-ref-parser
-
-  json-schema-ref-parser@6.1.0:
-    resolution:
-      { integrity: sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw== }
-    deprecated: Please switch to @apidevtools/json-schema-ref-parser
-
-  json-schema-to-openapi-schema@0.4.0:
-    resolution:
-      { integrity: sha512-/DY8s4l28M5ZIJBhmcUFWbZChJV5v7RCA7RMVxubyD1l5KwIceUq6+EUnqQ2q3wh/2D3Zn8bNSeAu1i2X+sMHQ== }
-    deprecated: This package is no longer maintained. Use @openapi-contrib/json-schema-to-openapi-schema instead.
-
-  json-schema-traverse@0.3.1:
-    resolution:
-      { integrity: sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA== }
 
   json-schema-traverse@0.4.1:
     resolution:
@@ -1730,58 +964,22 @@ packages:
     resolution:
       { integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug== }
 
-  json-schema@0.4.0:
-    resolution:
-      { integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA== }
-
   json-stable-stringify-without-jsonify@1.0.1:
     resolution:
       { integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw== }
-
-  json-stringify-safe@5.0.1:
-    resolution:
-      { integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA== }
 
   jsonc-parser@3.3.1:
     resolution:
       { integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ== }
 
-  jsonpath-plus@10.4.0:
-    resolution:
-      { integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA== }
-    engines: { node: '>=18.0.0' }
-    hasBin: true
-
-  jsonpath@0.2.12:
-    resolution:
-      { integrity: sha512-FnZhbj4Cr7/LNMIU8e9VWKMtrE/+/NMur/7maiW3uhAPI5qUcvf/hsR9zpjWBNzl2EkrW/NFyNUZ8V5sK7R/Fw== }
-
-  jsonpath@1.3.0:
-    resolution:
-      { integrity: sha512-0kjkYHJBkAy50Z5QzArZ7udmvxrJzkpKYW27fiF//BrMY7TQibYLl+FYIXN2BiYmwMIVzSfD8aDRj6IzgBX2/w== }
-
-  jsprim@1.4.2:
-    resolution:
-      { integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw== }
-    engines: { node: '>=0.6.0' }
-
   keyv@4.5.4:
     resolution:
       { integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw== }
-
-  lcid@1.0.0:
-    resolution:
-      { integrity: sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw== }
-    engines: { node: '>=0.10.0' }
 
   levn@0.4.1:
     resolution:
       { integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ== }
     engines: { node: '>= 0.8.0' }
-
-  lex-parser@0.1.4:
-    resolution:
-      { integrity: sha512-DuAEISsr1H4LOpmFLkyMc8YStiRWZCO8hMsoXAXSbgyfvs2WQhSt0+/FBv3ZU/JBFZMGcE+FWzEBSzwUU7U27w== }
 
   lightningcss-android-arm64@1.32.0:
     resolution:
@@ -1869,34 +1067,10 @@ packages:
       { integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ== }
     engines: { node: '>= 12.0.0' }
 
-  load-json-file@2.0.0:
-    resolution:
-      { integrity: sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ== }
-    engines: { node: '>=4' }
-
-  locate-path@2.0.0:
-    resolution:
-      { integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA== }
-    engines: { node: '>=4' }
-
   locate-path@6.0.0:
     resolution:
       { integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw== }
     engines: { node: '>=10' }
-
-  lodash.clonedeep@4.5.0:
-    resolution:
-      { integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ== }
-
-  lodash.get@4.4.2:
-    resolution:
-      { integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ== }
-    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
-
-  lodash.isequal@4.5.0:
-    resolution:
-      { integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ== }
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.merge@4.6.2:
     resolution:
@@ -1905,15 +1079,6 @@ packages:
   lodash@4.18.1:
     resolution:
       { integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q== }
-
-  lowercase-keys@1.0.1:
-    resolution:
-      { integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA== }
-    engines: { node: '>=0.10.0' }
-
-  lru-cache@4.1.5:
-    resolution:
-      { integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g== }
 
   magic-string@0.30.21:
     resolution:
@@ -1928,40 +1093,15 @@ packages:
       { integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g== }
     engines: { node: '>= 0.4' }
 
-  mem@1.1.0:
-    resolution:
-      { integrity: sha512-nOBDrc/wgpkd3X/JOhMqYR+/eLqlfLP4oQfoBA6QExIxEl+GU01oyEkwWyueyO8110pUKijtiHGhEmYoOn88oQ== }
-    engines: { node: '>=4' }
-
-  methods@1.1.2:
-    resolution:
-      { integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w== }
-    engines: { node: '>= 0.6' }
-
   mime-db@1.52.0:
     resolution:
       { integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg== }
     engines: { node: '>= 0.6' }
 
-  mime-lookup@0.0.2:
-    resolution:
-      { integrity: sha512-6384dzMc9tsk9wBt/W9jG1hWEUPk7oPwj0ExsJCAI9peB11GbWniOWg0O/Uf8vZbvK8bkPKPtaVDtZI0FWlwbg== }
-
   mime-types@2.1.35:
     resolution:
       { integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw== }
     engines: { node: '>= 0.6' }
-
-  mime@2.6.0:
-    resolution:
-      { integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg== }
-    engines: { node: '>=4.0.0' }
-    hasBin: true
-
-  mimic-fn@1.2.0:
-    resolution:
-      { integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ== }
-    engines: { node: '>=4' }
 
   minimatch@10.2.5:
     resolution:
@@ -1987,74 +1127,9 @@ packages:
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
-  native-promise-only@0.8.1:
-    resolution:
-      { integrity: sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg== }
-
   natural-compare@1.4.0:
     resolution:
       { integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw== }
-
-  node-fetch@1.7.3:
-    resolution:
-      { integrity: sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ== }
-
-  node-readfiles@0.2.0:
-    resolution:
-      { integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA== }
-
-  nomnom@1.5.2:
-    resolution:
-      { integrity: sha512-fiVbT7BqxiQqjlR9U3FDGOSERFCKoXVCdxV2FwZuNN7/cmJ42iQx35nUFOAFDcyvemu9Adp+IlsCGlKQYLmBKw== }
-    deprecated: Package no longer supported. Contact support@npmjs.com for more info.
-
-  nopt@3.0.6:
-    resolution:
-      { integrity: sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg== }
-    hasBin: true
-
-  normalize-package-data@2.5.0:
-    resolution:
-      { integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA== }
-
-  npm-run-path@2.0.2:
-    resolution:
-      { integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw== }
-    engines: { node: '>=4' }
-
-  number-is-nan@1.0.1:
-    resolution:
-      { integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ== }
-    engines: { node: '>=0.10.0' }
-
-  oauth-sign@0.9.0:
-    resolution:
-      { integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ== }
-
-  object-assign@2.1.1:
-    resolution:
-      { integrity: sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g== }
-    engines: { node: '>=0.10.0' }
-
-  object-assign@4.1.1:
-    resolution:
-      { integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg== }
-    engines: { node: '>=0.10.0' }
-
-  object-inspect@1.13.4:
-    resolution:
-      { integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew== }
-    engines: { node: '>= 0.4' }
-
-  object-keys@1.1.1:
-    resolution:
-      { integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA== }
-    engines: { node: '>= 0.4' }
-
-  object.assign@4.1.7:
-    resolution:
-      { integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw== }
-    engines: { node: '>= 0.4' }
 
   obug@2.1.2:
     resolution:
@@ -2065,10 +1140,6 @@ packages:
     resolution:
       { integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w== }
 
-  ono@4.0.11:
-    resolution:
-      { integrity: sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g== }
-
   openapi-types@12.1.3:
     resolution:
       { integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw== }
@@ -2078,60 +1149,20 @@ packages:
       { integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g== }
     engines: { node: '>= 0.8.0' }
 
-  os-locale@2.1.0:
-    resolution:
-      { integrity: sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA== }
-    engines: { node: '>=4' }
-
-  own-keys@1.0.1:
-    resolution:
-      { integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg== }
-    engines: { node: '>= 0.4' }
-
-  p-finally@1.0.0:
-    resolution:
-      { integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow== }
-    engines: { node: '>=4' }
-
-  p-limit@1.3.0:
-    resolution:
-      { integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q== }
-    engines: { node: '>=4' }
-
   p-limit@3.1.0:
     resolution:
       { integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ== }
     engines: { node: '>=10' }
-
-  p-locate@2.0.0:
-    resolution:
-      { integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg== }
-    engines: { node: '>=4' }
 
   p-locate@5.0.0:
     resolution:
       { integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw== }
     engines: { node: '>=10' }
 
-  p-try@1.0.0:
-    resolution:
-      { integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww== }
-    engines: { node: '>=4' }
-
   parent-module@1.0.1:
     resolution:
       { integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g== }
     engines: { node: '>=6' }
-
-  parse-json@2.2.0:
-    resolution:
-      { integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ== }
-    engines: { node: '>=0.10.0' }
-
-  path-exists@3.0.0:
-    resolution:
-      { integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ== }
-    engines: { node: '>=4' }
 
   path-exists@4.0.0:
     resolution:
@@ -2143,40 +1174,14 @@ packages:
       { integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg== }
     engines: { node: '>=0.10.0' }
 
-  path-key@2.0.1:
-    resolution:
-      { integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw== }
-    engines: { node: '>=4' }
-
   path-key@3.1.1:
     resolution:
       { integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q== }
     engines: { node: '>=8' }
 
-  path-loader@1.0.12:
-    resolution:
-      { integrity: sha512-n7oDG8B+k/p818uweWrOixY9/Dsr89o2TkCm6tOTex3fpdo2+BFDgR+KpB37mGKBRsBAlR8CIJMFN0OEy/7hIQ== }
-
-  path-parse@1.0.7:
-    resolution:
-      { integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw== }
-
-  path-to-regexp@1.9.0:
-    resolution:
-      { integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g== }
-
-  path-type@2.0.0:
-    resolution:
-      { integrity: sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ== }
-    engines: { node: '>=4' }
-
   pathe@2.0.3:
     resolution:
       { integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w== }
-
-  performance-now@2.1.0:
-    resolution:
-      { integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow== }
 
   picocolors@1.1.1:
     resolution:
@@ -2187,20 +1192,6 @@ packages:
       { integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A== }
     engines: { node: '>=12' }
 
-  pify@2.3.0:
-    resolution:
-      { integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog== }
-    engines: { node: '>=0.10.0' }
-
-  pluralize@1.1.6:
-    resolution:
-      { integrity: sha512-UZuZBoEfkgswguqcjVu6V59DVrILlC7GjclesLS6SA+u/+esH/f1FBW+BtzSMAz1mENIlM0Eo/89AIjxAFidQA== }
-
-  possible-typed-array-names@1.1.0:
-    resolution:
-      { integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg== }
-    engines: { node: '>= 0.4' }
-
   postcss@8.5.15:
     resolution:
       { integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A== }
@@ -2210,11 +1201,6 @@ packages:
     resolution:
       { integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g== }
     engines: { node: '>= 0.8.0' }
-
-  prepend-http@1.0.4:
-    resolution:
-      { integrity: sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg== }
-    engines: { node: '>=0.10.0' }
 
   prettier-linter-helpers@1.0.1:
     resolution:
@@ -2227,125 +1213,29 @@ packages:
     engines: { node: '>=14' }
     hasBin: true
 
-  process-nextick-args@2.0.1:
-    resolution:
-      { integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag== }
-
   proxy-from-env@2.1.0:
     resolution:
       { integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA== }
     engines: { node: '>=10' }
-
-  pseudomap@1.0.2:
-    resolution:
-      { integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ== }
-
-  psl@1.15.0:
-    resolution:
-      { integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w== }
 
   punycode@2.3.1:
     resolution:
       { integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg== }
     engines: { node: '>=6' }
 
-  q@0.9.7:
-    resolution:
-      { integrity: sha512-ijt0LhxWClXBtc1RCt8H0WhlZLAdVX26nWbpsJy+Hblmp81d2F/pFsvlrJhJDDruFHM+ECtxP0H0HzGSrARkwg== }
-    engines: { node: '>=0.6.0', teleport: '>=0.2.0' }
-    deprecated: |-
-      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
-      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
-
-  qs@6.15.2:
-    resolution:
-      { integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw== }
-    engines: { node: '>=0.6' }
-
-  qs@6.5.5:
-    resolution:
-      { integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ== }
-    engines: { node: '>=0.6' }
-
   queue-microtask@1.2.3:
     resolution:
       { integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A== }
-
-  raml-parser@0.8.18:
-    resolution:
-      { integrity: sha512-WpKlKhxN7mXJ1Kf5/7f7+EMOsXNwjI4TbrY6TkbR+bzzdFMTjz8oqPJdDkr7gA+ow5vvzCfe16+tUhmSNnkcNQ== }
-    hasBin: true
-
-  raml-to-swagger@1.1.0:
-    resolution:
-      { integrity: sha512-aDsSklVNG1xOAXenzmX8+Pfq+G95esQNx5WQo/qa/AtVPm3KsM6zI6hw3oYE6whocfnogwpnbJSFbTrADwpZIg== }
-    hasBin: true
-
-  read-all-stream@1.0.2:
-    resolution:
-      { integrity: sha512-ZCvB3TY2z5hGzzNe7zotaFsuRt4ODw5o+EVjfDVwlFG3ihfTd0k8jy9ffWZ4V1tCm0UHscbiS9KYREaq8eGE1Q== }
-    engines: { node: '>=0.10.0' }
-
-  read-pkg-up@2.0.0:
-    resolution:
-      { integrity: sha512-1orxQfbWGUiTn9XsPlChs6rLie/AV9jwZTGmu2NZw/CUDJQchXJFYE0Fq5j7+n558T1JhDWLdhyd1Zj+wLY//w== }
-    engines: { node: '>=4' }
-
-  read-pkg@2.0.0:
-    resolution:
-      { integrity: sha512-eFIBOPW7FGjzBuk3hdXEuNSiTZS/xEMlH49HxMyzb0hyPfu4EhVjT2DH32K1hSSmVq4sebAWnZuuY5auISUTGA== }
-    engines: { node: '>=4' }
-
-  readable-stream@2.3.8:
-    resolution:
-      { integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA== }
-
-  readable-stream@3.6.2:
-    resolution:
-      { integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA== }
-    engines: { node: '>= 6' }
-
-  reflect.getprototypeof@1.0.10:
-    resolution:
-      { integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw== }
-    engines: { node: '>= 0.4' }
-
-  regexp.prototype.flags@1.5.4:
-    resolution:
-      { integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA== }
-    engines: { node: '>= 0.4' }
-
-  request@2.88.2:
-    resolution:
-      { integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw== }
-    engines: { node: '>= 6' }
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-
-  require-directory@2.1.1:
-    resolution:
-      { integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q== }
-    engines: { node: '>=0.10.0' }
 
   require-from-string@2.0.2:
     resolution:
       { integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw== }
     engines: { node: '>=0.10.0' }
 
-  require-main-filename@1.0.1:
-    resolution:
-      { integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug== }
-
   resolve-from@4.0.0:
     resolution:
       { integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g== }
     engines: { node: '>=4' }
-
-  resolve@1.22.12:
-    resolution:
-      { integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA== }
-    engines: { node: '>= 0.4' }
-    hasBin: true
 
   reusify@1.1.0:
     resolution:
@@ -2368,316 +1258,53 @@ packages:
     resolution:
       { integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA== }
 
-  safe-array-concat@1.1.4:
-    resolution:
-      { integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg== }
-    engines: { node: '>=0.4' }
-
-  safe-buffer@5.1.2:
-    resolution:
-      { integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g== }
-
-  safe-buffer@5.2.1:
-    resolution:
-      { integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ== }
-
-  safe-push-apply@1.0.0:
-    resolution:
-      { integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA== }
-    engines: { node: '>= 0.4' }
-
-  safe-regex-test@1.1.0:
-    resolution:
-      { integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw== }
-    engines: { node: '>= 0.4' }
-
-  safer-buffer@2.1.2:
-    resolution:
-      { integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg== }
-
-  sax@1.6.0:
-    resolution:
-      { integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA== }
-    engines: { node: '>=11.0.0' }
-
-  semver@5.7.2:
-    resolution:
-      { integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g== }
-    hasBin: true
-
   semver@7.8.2:
     resolution:
       { integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ== }
     engines: { node: '>=10' }
     hasBin: true
 
-  set-blocking@2.0.0:
-    resolution:
-      { integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw== }
-
-  set-function-length@1.2.2:
-    resolution:
-      { integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg== }
-    engines: { node: '>= 0.4' }
-
-  set-function-name@2.0.2:
-    resolution:
-      { integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ== }
-    engines: { node: '>= 0.4' }
-
-  set-proto@1.0.0:
-    resolution:
-      { integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw== }
-    engines: { node: '>= 0.4' }
-
-  shebang-command@1.2.0:
-    resolution:
-      { integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg== }
-    engines: { node: '>=0.10.0' }
-
   shebang-command@2.0.0:
     resolution:
       { integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA== }
     engines: { node: '>=8' }
-
-  shebang-regex@1.0.0:
-    resolution:
-      { integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ== }
-    engines: { node: '>=0.10.0' }
 
   shebang-regex@3.0.0:
     resolution:
       { integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A== }
     engines: { node: '>=8' }
 
-  should-equal@2.0.0:
-    resolution:
-      { integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA== }
-
-  should-format@3.0.3:
-    resolution:
-      { integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q== }
-
-  should-type-adaptors@1.1.0:
-    resolution:
-      { integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA== }
-
-  should-type@1.4.0:
-    resolution:
-      { integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ== }
-
-  should-util@1.0.1:
-    resolution:
-      { integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g== }
-
-  should@13.2.3:
-    resolution:
-      { integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ== }
-
-  side-channel-list@1.0.1:
-    resolution:
-      { integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w== }
-    engines: { node: '>= 0.4' }
-
-  side-channel-map@1.0.1:
-    resolution:
-      { integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA== }
-    engines: { node: '>= 0.4' }
-
-  side-channel-weakmap@1.0.2:
-    resolution:
-      { integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A== }
-    engines: { node: '>= 0.4' }
-
-  side-channel@1.1.0:
-    resolution:
-      { integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw== }
-    engines: { node: '>= 0.4' }
-
   siginfo@2.0.0:
     resolution:
       { integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g== }
-
-  signal-exit@3.0.7:
-    resolution:
-      { integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ== }
-
-  slash@3.0.0:
-    resolution:
-      { integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q== }
-    engines: { node: '>=8' }
 
   source-map-js@1.2.1:
     resolution:
       { integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA== }
     engines: { node: '>=0.10.0' }
 
-  source-map@0.6.0:
-    resolution:
-      { integrity: sha512-mTozplhTX4tLKIHYji92OTZzVyZvi+Z1qRZDeBvQFI2XUB89wrRoj/xXad3c9NZ1GPJXXRvB+k41PQCPTMC+aA== }
-    engines: { node: '>=0.10.0' }
-
-  source-map@0.6.1:
-    resolution:
-      { integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g== }
-    engines: { node: '>=0.10.0' }
-
-  spdx-correct@3.2.0:
-    resolution:
-      { integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA== }
-
-  spdx-exceptions@2.5.0:
-    resolution:
-      { integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w== }
-
-  spdx-expression-parse@3.0.1:
-    resolution:
-      { integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q== }
-
-  spdx-license-ids@3.0.23:
-    resolution:
-      { integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw== }
-
-  sprintf-js@1.0.3:
-    resolution:
-      { integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g== }
-
-  sshpk@1.18.0:
-    resolution:
-      { integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ== }
-    engines: { node: '>=0.10.0' }
-    hasBin: true
-
   stackback@0.0.2:
     resolution:
       { integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw== }
 
-  static-eval@0.2.3:
-    resolution:
-      { integrity: sha512-tAlLR3cdYw5GOEJfGqsL3YqwwldzljwqoOJ/jjFMmNRI9/iqve9RX4XE3vJs1KKsQ+ECT1u9o7a6NonewRl1lg== }
-
-  static-eval@2.1.1:
-    resolution:
-      { integrity: sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA== }
-
-  statuses@1.5.0:
-    resolution:
-      { integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA== }
-    engines: { node: '>= 0.6' }
-
   std-env@4.1.0:
     resolution:
       { integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ== }
-
-  stop-iteration-iterator@1.1.0:
-    resolution:
-      { integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ== }
-    engines: { node: '>= 0.4' }
-
-  stream-shift@1.0.3:
-    resolution:
-      { integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ== }
-
-  string-width@1.0.2:
-    resolution:
-      { integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw== }
-    engines: { node: '>=0.10.0' }
-
-  string-width@2.1.1:
-    resolution:
-      { integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw== }
-    engines: { node: '>=4' }
-
-  string.prototype.trim@1.2.11:
-    resolution:
-      { integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w== }
-    engines: { node: '>= 0.4' }
-
-  string.prototype.trimend@1.0.10:
-    resolution:
-      { integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw== }
-    engines: { node: '>= 0.4' }
-
-  string.prototype.trimstart@1.0.8:
-    resolution:
-      { integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg== }
-    engines: { node: '>= 0.4' }
-
-  string_decoder@1.1.1:
-    resolution:
-      { integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg== }
-
-  string_decoder@1.3.0:
-    resolution:
-      { integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA== }
-
-  strip-ansi@3.0.1:
-    resolution:
-      { integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg== }
-    engines: { node: '>=0.10.0' }
-
-  strip-ansi@4.0.0:
-    resolution:
-      { integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow== }
-    engines: { node: '>=4' }
 
   strip-ansi@6.0.1:
     resolution:
       { integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A== }
     engines: { node: '>=8' }
 
-  strip-bom@3.0.0:
-    resolution:
-      { integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA== }
-    engines: { node: '>=4' }
-
-  strip-eof@1.0.0:
-    resolution:
-      { integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q== }
-    engines: { node: '>=0.10.0' }
-
   strip-json-comments@3.1.1:
     resolution:
       { integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig== }
     engines: { node: '>=8' }
 
-  superagent@7.1.6:
-    resolution:
-      { integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g== }
-    engines: { node: '>=6.4.0 <13 || >=14' }
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
-
   supports-color@7.2.0:
     resolution:
       { integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw== }
     engines: { node: '>=8' }
-
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution:
-      { integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w== }
-    engines: { node: '>= 0.4' }
-
-  swagger-converter@1.5.1:
-    resolution:
-      { integrity: sha512-u98/Gt+fAnS95WoUDgWuOiN8MymrNCUdcLoD4Q6szy4nAj9BPCVRzwvJauqqj7+jKcB1ZEKf9vacQKSXEr3OBw== }
-
-  swagger-methods@1.0.8:
-    resolution:
-      { integrity: sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA== }
-    deprecated: This package is no longer being maintained.
-
-  swagger-schema-official@2.0.0-bab6bed:
-    resolution:
-      { integrity: sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA== }
-
-  swagger2openapi@2.9.4:
-    resolution:
-      { integrity: sha512-dc9gxEkxuJYPz9y0Fx3ypsaiA2enxHxz7Q0tlyjJ01TopT2aR/EuxZhIWkslaN/Fx5FTT2OOSlP5VnvTbvIj+Q== }
-    hasBin: true
-
-  sway@2.0.6:
-    resolution:
-      { integrity: sha512-0HRT2WuU44XIdq+eCiMx67Bl/kiEKORP+4j+Wt89rFjoR5Dwx2hmU4PkMA6hnd48XLfS50olIac3pQGrV/wv7w== }
 
   synckit@0.11.13:
     resolution:
@@ -2687,11 +1314,6 @@ packages:
   text-table@0.2.0:
     resolution:
       { integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw== }
-
-  timed-out@2.0.0:
-    resolution:
-      { integrity: sha512-pqqJOi1rF5zNs/ps4vmbE4SFCrM4iR7LW+GHAsHqO/EumqbIWceioevYLM5xZRgQSH6gFgL9J/uB7EcJhQ9niQ== }
-    engines: { node: '>=0.10.0' }
 
   tinybench@2.9.0:
     resolution:
@@ -2711,16 +1333,6 @@ packages:
     resolution:
       { integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw== }
     engines: { node: '>=14.0.0' }
-
-  tough-cookie@2.5.0:
-    resolution:
-      { integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g== }
-    engines: { node: '>=0.8' }
-
-  traverse@0.6.11:
-    resolution:
-      { integrity: sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w== }
-    engines: { node: '>= 0.4' }
 
   ts-api-utils@2.5.0:
     resolution:
@@ -2748,14 +1360,6 @@ packages:
     resolution:
       { integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w== }
 
-  tunnel-agent@0.6.0:
-    resolution:
-      { integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w== }
-
-  tweetnacl@0.14.5:
-    resolution:
-      { integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA== }
-
   type-check@0.4.0:
     resolution:
       { integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew== }
@@ -2766,58 +1370,11 @@ packages:
       { integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ== }
     engines: { node: '>=10' }
 
-  type-of-is@3.5.1:
-    resolution:
-      { integrity: sha512-SOnx8xygcAh8lvDU2exnK2bomASfNjzB3Qz71s2tw9QnX8fkAo7aC+D0H7FV0HjRKj94CKV2Hi71kVkkO6nOxg== }
-    engines: { node: '>=0.10.5' }
-
-  typed-array-buffer@1.0.3:
-    resolution:
-      { integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw== }
-    engines: { node: '>= 0.4' }
-
-  typed-array-byte-length@1.0.3:
-    resolution:
-      { integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg== }
-    engines: { node: '>= 0.4' }
-
-  typed-array-byte-offset@1.0.4:
-    resolution:
-      { integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ== }
-    engines: { node: '>= 0.4' }
-
-  typed-array-length@1.0.8:
-    resolution:
-      { integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g== }
-    engines: { node: '>= 0.4' }
-
-  typedarray.prototype.slice@1.0.5:
-    resolution:
-      { integrity: sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg== }
-    engines: { node: '>= 0.4' }
-
   typescript@5.9.3:
     resolution:
       { integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw== }
     engines: { node: '>=14.17' }
     hasBin: true
-
-  unbox-primitive@1.1.0:
-    resolution:
-      { integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw== }
-    engines: { node: '>= 0.4' }
-
-  underscore@1.1.7:
-    resolution:
-      { integrity: sha512-w4QtCHoLBXw1mjofIDoMyexaEdWGMedWNDhlWTtT1V1lCRqi65Pnoygkh6+WRdr+Bm8ldkBNkNeCsXGMlQS9HQ== }
-
-  underscore@1.13.6:
-    resolution:
-      { integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A== }
-
-  underscore@1.7.0:
-    resolution:
-      { integrity: sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA== }
 
   undici-types@6.21.0:
     resolution:
@@ -2827,41 +1384,9 @@ packages:
     resolution:
       { integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg== }
 
-  urijs@1.19.11:
-    resolution:
-      { integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ== }
-
-  uritemplate@0.3.4:
-    resolution:
-      { integrity: sha512-enADBvHfhjrwxFMTVWeIIYz51SZ91uC6o2MR/NQTVljJB6HTZ8eQL3Q7JBj3RxNISA14MOwJaU3vpf5R6dyxHA== }
-
-  util-deprecate@1.0.2:
-    resolution:
-      { integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw== }
-
-  uuid@3.4.0:
-    resolution:
-      { integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A== }
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution:
       { integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg== }
-
-  validate-npm-package-license@3.0.4:
-    resolution:
-      { integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew== }
-
-  validator@10.11.0:
-    resolution:
-      { integrity: sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw== }
-    engines: { node: '>= 0.10' }
-
-  verror@1.10.0:
-    resolution:
-      { integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw== }
-    engines: { '0': node >=0.6.0 }
 
   vite@8.0.16:
     resolution:
@@ -2949,35 +1474,6 @@ packages:
       jsdom:
         optional: true
 
-  which-boxed-primitive@1.1.1:
-    resolution:
-      { integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA== }
-    engines: { node: '>= 0.4' }
-
-  which-builtin-type@1.2.1:
-    resolution:
-      { integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q== }
-    engines: { node: '>= 0.4' }
-
-  which-collection@1.0.2:
-    resolution:
-      { integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw== }
-    engines: { node: '>= 0.4' }
-
-  which-module@2.0.1:
-    resolution:
-      { integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ== }
-
-  which-typed-array@1.1.22:
-    resolution:
-      { integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw== }
-    engines: { node: '>= 0.4' }
-
-  which@1.3.1:
-    resolution:
-      { integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ== }
-    hasBin: true
-
   which@2.0.2:
     resolution:
       { integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA== }
@@ -2995,40 +1491,9 @@ packages:
       { integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA== }
     engines: { node: '>=0.10.0' }
 
-  wrap-ansi@2.1.0:
-    resolution:
-      { integrity: sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw== }
-    engines: { node: '>=0.10.0' }
-
   wrappy@1.0.2:
     resolution:
       { integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ== }
-
-  xml2js@0.4.23:
-    resolution:
-      { integrity: sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug== }
-    engines: { node: '>=4.0.0' }
-
-  xmlbuilder@11.0.1:
-    resolution:
-      { integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA== }
-    engines: { node: '>=4.0' }
-
-  y18n@3.2.2:
-    resolution:
-      { integrity: sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ== }
-
-  yallist@2.1.2:
-    resolution:
-      { integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A== }
-
-  yargs-parser@7.0.0:
-    resolution:
-      { integrity: sha512-WhzC+xgstid9MbVUktco/bf+KJG+Uu6vMX0LN1sLJvwmbCQVxb4D8LzogobonKycNasCZLdOzTAk1SK7+K7swg== }
-
-  yargs@9.0.1:
-    resolution:
-      { integrity: sha512-XS0NJoM9Iz0azh1cdgfLF5VFK6BSWfrrqA0V2tIx3fV6aGrWCseVDwOkIBg746ev0hes59od5ZvQAfdET4H0pw== }
 
   yn@3.1.1:
     resolution:
@@ -3039,11 +1504,6 @@ packages:
     resolution:
       { integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q== }
     engines: { node: '>=10' }
-
-  z-schema@3.25.1:
-    resolution:
-      { integrity: sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q== }
-    hasBin: true
 
 snapshots:
   '@apidevtools/json-schema-ref-parser@14.0.1':
@@ -3064,9 +1524,6 @@ snapshots:
       ajv-draft-04: 1.0.0(ajv@8.20.0)
       call-me-maybe: 1.0.2
       openapi-types: 12.1.3
-
-  '@cloudflare/json-schema-walker@0.1.1':
-    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3132,22 +1589,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
-    dependencies:
-      jsep: 1.4.0
-
-  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
-    dependencies:
-      jsep: 1.4.0
-
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
-
-  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3162,10 +1609,6 @@ snapshots:
       fastq: 1.20.1
 
   '@oxc-project/types@0.133.0': {}
-
-  '@paralleldrive/cuid2@2.3.1':
-    dependencies:
-      '@noble/hashes': 1.8.0
 
   '@pkgr/core@0.3.6': {}
 
@@ -3246,11 +1689,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/keyv@3.1.4':
-    dependencies:
-      '@types/node': 22.19.19
-    optional: true
-
   '@types/lodash@4.17.24': {}
 
   '@types/mustache@4.2.6': {}
@@ -3258,11 +1696,6 @@ snapshots:
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/responselike@1.0.3':
-    dependencies:
-      '@types/node': 22.19.19
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -3398,12 +1831,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  JSONSelect@0.4.0:
-    optional: true
-
-  abbrev@1.1.1:
-    optional: true
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3424,14 +1851,6 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
-  ajv@5.5.2:
-    dependencies:
-      co: 4.6.0
-      fast-deep-equal: 1.1.0
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.3.1
-    optional: true
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3446,103 +1865,19 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-regex@2.1.1:
-    optional: true
-
-  ansi-regex@3.0.1:
-    optional: true
-
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
-  api-spec-converter@2.12.0:
-    dependencies:
-      bluebird: 3.7.2
-      commander: 2.20.3
-      composite-error: 0.1.1
-      deep-sort-object: 1.0.2
-      js-yaml: 3.14.2
-      lodash: 4.18.1
-      lodash.clonedeep: 4.5.0
-      request: 2.88.2
-      source-map: 0.6.0
-      sway: 2.0.6
-      traverse: 0.6.11
-      urijs: 1.19.11
-      xml2js: 0.4.23
-    optionalDependencies:
-      apib2swagger: 1.17.1
-      drafter.js: 2.6.7
-      google-discovery-to-swagger: 2.1.0
-      raml-parser: 0.8.18
-      raml-to-swagger: 1.1.0
-      swagger-converter: 1.5.1
-      swagger2openapi: 2.9.4
-    transitivePeerDependencies:
-      - supports-color
-
-  apib-include-directive@0.1.0:
-    optional: true
-
-  apib2swagger@1.17.1:
-    dependencies:
-      apib-include-directive: 0.1.0
-      drafter.js: 2.6.7
-      generate-schema: 2.6.0
-      js-yaml: 4.2.0
-      json-schema-to-openapi-schema: 0.4.0
-      lodash.isequal: 4.5.0
-      nopt: 3.0.6
-      uritemplate: 0.3.4
-    optional: true
-
   arg@4.1.3: {}
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
-  array-buffer-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      is-array-buffer: 3.0.5
-
-  arraybuffer.prototype.slice@1.0.4:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      is-array-buffer: 3.0.5
-
-  asap@2.0.6: {}
-
-  asn1@0.2.6:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  assert-plus@1.0.0: {}
-
   assertion-error@2.0.1: {}
 
-  async-function@1.0.0: {}
-
   asynckit@0.4.0: {}
-
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.1.0
-
-  aws-sign2@0.7.0: {}
-
-  aws4@1.13.2: {}
 
   axios@1.17.0:
     dependencies:
@@ -3558,12 +1893,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  bcrypt-pbkdf@1.0.2:
-    dependencies:
-      tweetnacl: 0.14.5
-
-  bluebird@3.7.2: {}
-
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -3578,26 +1907,9 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.9:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
   call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
-
-  camelcase@4.1.0:
-    optional: true
-
-  caseless@0.12.0: {}
 
   chai@6.2.2: {}
 
@@ -3606,30 +1918,11 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  cjson@0.2.1:
-    optional: true
-
-  cliui@3.2.0:
-    dependencies:
-      string-width: 1.0.2
-      strip-ansi: 3.0.1
-      wrap-ansi: 2.1.0
-    optional: true
-
-  co@4.6.0:
-    optional: true
-
-  code-point-at@1.1.0:
-    optional: true
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  colors@0.5.1:
-    optional: true
 
   combined-stream@1.0.8:
     dependencies:
@@ -3637,38 +1930,11 @@ snapshots:
 
   commander@15.0.0: {}
 
-  commander@2.20.3: {}
-
-  commander@4.1.1: {}
-
-  common-prefix@1.1.0:
-    optional: true
-
-  component-emitter@1.3.1: {}
-
-  composite-error@0.1.1: {}
-
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
-  cookiejar@2.1.4: {}
-
-  core-js@2.6.12: {}
-
-  core-util-is@1.0.2: {}
-
-  core-util-is@1.0.3:
-    optional: true
-
   create-require@1.1.1: {}
-
-  cross-spawn@5.1.0:
-    dependencies:
-      lru-cache: 4.1.5
-      shebang-command: 1.2.0
-      which: 1.3.1
-    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3676,65 +1942,15 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  dashdash@1.14.1:
-    dependencies:
-      assert-plus: 1.0.0
-
-  data-view-buffer@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-offset@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  debug@3.2.7:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
-  decamelize@1.2.0:
-    optional: true
-
   deep-is@0.1.4: {}
-
-  deep-sort-object@1.0.2:
-    dependencies:
-      is-plain-object: 2.0.4
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
-
-  dezalgo@1.0.4:
-    dependencies:
-      asap: 2.0.6
-      wrappy: 1.0.2
 
   diff@4.0.4: {}
 
@@ -3742,102 +1958,11 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  drafter.js@2.6.7:
-    optional: true
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  duplexify@3.7.1:
-    dependencies:
-      end-of-stream: 1.4.5
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      stream-shift: 1.0.3
-    optional: true
-
-  ebnf-parser@0.1.10:
-    optional: true
-
-  ecc-jsbn@0.1.2:
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-    optional: true
-
-  error-ex@1.3.4:
-    dependencies:
-      is-arrayish: 0.2.1
-    optional: true
-
-  es-abstract@1.24.2:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      arraybuffer.prototype.slice: 1.0.4
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      data-view-buffer: 1.0.2
-      data-view-byte-length: 1.0.2
-      data-view-byte-offset: 1.0.1
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.3.0
-      function.prototype.name: 1.1.8
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      get-symbol-description: 1.1.0
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      internal-slot: 1.1.0
-      is-array-buffer: 3.0.5
-      is-callable: 1.2.7
-      is-data-view: 1.0.2
-      is-negative-zero: 2.0.3
-      is-regex: 1.2.1
-      is-set: 2.0.3
-      is-shared-array-buffer: 1.0.4
-      is-string: 1.1.1
-      is-typed-array: 1.1.15
-      is-weakref: 1.1.1
-      math-intrinsics: 1.1.0
-      object-inspect: 1.13.4
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      own-keys: 1.0.1
-      regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.4
-      safe-push-apply: 1.0.0
-      safe-regex-test: 1.1.0
-      set-proto: 1.0.0
-      stop-iteration-iterator: 1.1.0
-      string.prototype.trim: 1.2.11
-      string.prototype.trimend: 1.0.10
-      string.prototype.trimstart: 1.0.8
-      typed-array-buffer: 1.0.3
-      typed-array-byte-length: 1.0.3
-      typed-array-byte-offset: 1.0.4
-      typed-array-length: 1.0.8
-      unbox-primitive: 1.1.0
-      which-typed-array: 1.1.22
 
   es-define-property@1.0.1: {}
 
@@ -3856,44 +1981,7 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  es-to-primitive@1.3.0:
-    dependencies:
-      is-callable: 1.2.7
-      is-date-object: 1.1.0
-      is-symbol: 1.1.1
-
-  es6-promise@3.3.1:
-    optional: true
-
-  es6-promise@4.2.8:
-    optional: true
-
   escape-string-regexp@4.0.0: {}
-
-  escodegen@0.0.21:
-    dependencies:
-      esprima: 1.0.4
-      estraverse: 0.0.4
-    optionalDependencies:
-      source-map: 0.6.0
-    optional: true
-
-  escodegen@0.0.28:
-    dependencies:
-      esprima: 1.0.4
-      estraverse: 1.3.2
-    optionalDependencies:
-      source-map: 0.6.0
-    optional: true
-
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-    optional: true
 
   eslint-config-prettier@10.1.8(eslint@8.57.1):
     dependencies:
@@ -3966,17 +2054,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 3.4.3
 
-  esprima@1.0.4:
-    optional: true
-
-  esprima@1.2.2:
-    optional: true
-
-  esprima@1.2.5:
-    optional: true
-
-  esprima@4.0.1: {}
-
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -3984,12 +2061,6 @@ snapshots:
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
-
-  estraverse@0.0.4:
-    optional: true
-
-  estraverse@1.3.2:
-    optional: true
 
   estraverse@5.3.0: {}
 
@@ -3999,27 +2070,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  execa@0.7.0:
-    dependencies:
-      cross-spawn: 5.1.0
-      get-stream: 3.0.0
-      is-stream: 1.1.0
-      npm-run-path: 2.0.2
-      p-finally: 1.0.0
-      signal-exit: 3.0.7
-      strip-eof: 1.0.0
-    optional: true
-
   expect-type@1.3.0: {}
-
-  extend@3.0.2: {}
-
-  extsprintf@1.3.0: {}
-
-  faker@4.1.0: {}
-
-  fast-deep-equal@1.1.0:
-    optional: true
 
   fast-deep-equal@3.1.3: {}
 
@@ -4028,8 +2079,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.2: {}
 
@@ -4044,11 +2093,6 @@ snapshots:
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
-
-  find-up@2.1.0:
-    dependencies:
-      locate-path: 2.0.0
-    optional: true
 
   find-up@5.0.0:
     dependencies:
@@ -4065,18 +2109,6 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
-  for-each@0.3.5:
-    dependencies:
-      is-callable: 1.2.7
-
-  forever-agent@0.6.1: {}
-
-  form-data@2.3.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -4085,43 +2117,12 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
-  format-util@1.0.5: {}
-
-  formidable@2.1.5:
-    dependencies:
-      '@paralleldrive/cuid2': 2.3.1
-      dezalgo: 1.0.4
-      once: 1.4.0
-      qs: 6.15.2
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
-
-  function.prototype.name@1.1.8:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      functions-have-names: 1.2.3
-      hasown: 2.0.4
-      is-callable: 1.2.7
-
-  functions-have-names@1.2.3: {}
-
-  generate-schema@2.6.0:
-    dependencies:
-      commander: 2.20.3
-      type-of-is: 3.5.1
-    optional: true
-
-  generator-function@2.0.1: {}
-
-  get-caller-file@1.0.3:
-    optional: true
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4141,19 +2142,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  get-stream@3.0.0:
-    optional: true
-
-  get-symbol-description@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-
-  getpass@0.1.7:
-    dependencies:
-      assert-plus: 1.0.0
-
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -4171,66 +2159,11 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
-  globalthis@1.0.4:
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.2.0
-
-  google-discovery-to-swagger@2.1.0:
-    dependencies:
-      json-schema-compatibility: 1.1.0
-      jsonpath: 1.3.0
-      lodash: 4.18.1
-      mime-db: 1.52.0
-      mime-lookup: 0.0.2
-      traverse: 0.6.11
-      urijs: 1.19.11
-    optional: true
-
   gopd@1.2.0: {}
-
-  got@2.4.0:
-    dependencies:
-      '@types/keyv': 3.1.4
-      '@types/responselike': 1.0.3
-      duplexify: 3.7.1
-      infinity-agent: 1.0.2
-      is-stream: 1.1.0
-      lowercase-keys: 1.0.1
-      object-assign: 2.1.1
-      prepend-http: 1.0.4
-      read-all-stream: 1.0.2
-      statuses: 1.5.0
-      timed-out: 2.0.0
-    optional: true
-
-  graceful-fs@4.2.11:
-    optional: true
 
   graphemer@1.4.0: {}
 
-  graphlib@2.1.8:
-    dependencies:
-      lodash: 4.18.1
-
-  har-schema@2.0.0: {}
-
-  har-validator@5.1.5:
-    dependencies:
-      ajv: 6.15.0
-      har-schema: 2.0.0
-
-  has-bigints@1.1.0: {}
-
   has-flag@4.0.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
-  has-proto@1.2.0:
-    dependencies:
-      dunder-proto: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -4242,29 +2175,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hosted-git-info@2.8.9:
-    optional: true
-
-  http-signature@1.2.0:
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.18.0
-
-  http-status-codes@1.4.0:
-    optional: true
-
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-    optional: true
 
   ignore@5.3.2: {}
 
@@ -4277,9 +2193,6 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  infinity-agent@1.0.2:
-    optional: true
-
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -4287,301 +2200,38 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  internal-slot@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.4
-      side-channel: 1.1.0
-
-  invert-kv@1.0.0:
-    optional: true
-
-  is-array-buffer@3.0.5:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
-  is-arrayish@0.2.1:
-    optional: true
-
-  is-async-function@2.1.1:
-    dependencies:
-      async-function: 1.0.0
-      call-bound: 1.0.4
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
-
-  is-bigint@1.1.0:
-    dependencies:
-      has-bigints: 1.1.0
-
-  is-boolean-object@1.2.2:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-callable@1.2.7: {}
-
-  is-core-module@2.16.2:
-    dependencies:
-      hasown: 2.0.4
-    optional: true
-
-  is-data-view@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      is-typed-array: 1.1.15
-
-  is-date-object@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
   is-extglob@2.1.1: {}
-
-  is-finalizationregistry@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-fullwidth-code-point@1.0.0:
-    dependencies:
-      number-is-nan: 1.0.1
-    optional: true
-
-  is-fullwidth-code-point@2.0.0:
-    optional: true
-
-  is-generator-function@1.1.2:
-    dependencies:
-      call-bound: 1.0.4
-      generator-function: 2.0.1
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
-  is-map@2.0.3: {}
-
-  is-negative-zero@2.0.3: {}
-
-  is-number-object@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
   is-path-inside@3.0.3: {}
 
-  is-plain-object@2.0.4:
-    dependencies:
-      isobject: 3.0.1
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
-
-  is-set@2.0.3: {}
-
-  is-shared-array-buffer@1.0.4:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-stream@1.1.0:
-    optional: true
-
-  is-string@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-symbol@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-symbols: 1.1.0
-      safe-regex-test: 1.1.0
-
-  is-typed-array@1.1.15:
-    dependencies:
-      which-typed-array: 1.1.22
-
-  is-typedarray@1.0.0: {}
-
-  is-weakmap@2.0.2: {}
-
-  is-weakref@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-weakset@2.0.4:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
-  isarray@0.0.1: {}
-
-  isarray@1.0.0:
-    optional: true
-
-  isarray@2.0.5: {}
-
   isexe@2.0.0: {}
-
-  isobject@3.0.1: {}
-
-  isstream@0.1.2: {}
-
-  jgexml@0.3.9:
-    optional: true
-
-  jison-lex@0.2.1:
-    dependencies:
-      lex-parser: 0.1.4
-      nomnom: 1.5.2
-    optional: true
-
-  jison@0.4.13:
-    dependencies:
-      JSONSelect: 0.4.0
-      cjson: 0.2.1
-      ebnf-parser: 0.1.10
-      escodegen: 0.0.21
-      esprima: 1.0.4
-      jison-lex: 0.2.1
-      lex-parser: 0.1.4
-      nomnom: 1.5.2
-    optional: true
-
-  jju@1.2.1:
-    optional: true
-
-  js-base64@2.6.4: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
-  jsbn@0.1.1: {}
-
-  jsep@1.4.0: {}
-
   json-buffer@3.0.1: {}
-
-  json-refs@3.0.15:
-    dependencies:
-      commander: 4.1.1
-      graphlib: 2.1.8
-      js-yaml: 3.14.2
-      lodash: 4.18.1
-      native-promise-only: 0.8.1
-      path-loader: 1.0.12
-      slash: 3.0.0
-      uri-js: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
-  json-schema-compatibility@1.1.0:
-    optional: true
-
-  json-schema-faker@0.5.9:
-    dependencies:
-      json-schema-ref-parser: 6.1.0
-      jsonpath-plus: 10.4.0
-
-  json-schema-ref-parser@3.3.1:
-    dependencies:
-      call-me-maybe: 1.0.2
-      debug: 3.2.7
-      es6-promise: 4.2.8
-      js-yaml: 3.14.2
-      ono: 4.0.11
-      z-schema: 3.25.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  json-schema-ref-parser@6.1.0:
-    dependencies:
-      call-me-maybe: 1.0.2
-      js-yaml: 3.14.2
-      ono: 4.0.11
-
-  json-schema-to-openapi-schema@0.4.0:
-    dependencies:
-      '@cloudflare/json-schema-walker': 0.1.1
-    optional: true
-
-  json-schema-traverse@0.3.1:
-    optional: true
 
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
-  json-schema@0.4.0: {}
-
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1: {}
-
   jsonc-parser@3.3.1: {}
-
-  jsonpath-plus@10.4.0:
-    dependencies:
-      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
-      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
-      jsep: 1.4.0
-
-  jsonpath@0.2.12:
-    dependencies:
-      esprima: 1.2.2
-      jison: 0.4.13
-      static-eval: 0.2.3
-      underscore: 1.7.0
-    optional: true
-
-  jsonpath@1.3.0:
-    dependencies:
-      esprima: 1.2.5
-      static-eval: 2.1.1
-      underscore: 1.13.6
-    optional: true
-
-  jsprim@1.4.2:
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
 
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
-  lcid@1.0.0:
-    dependencies:
-      invert-kv: 1.0.0
-    optional: true
-
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  lex-parser@0.1.4:
-    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4632,42 +2282,13 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  load-json-file@2.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      parse-json: 2.2.0
-      pify: 2.3.0
-      strip-bom: 3.0.0
-    optional: true
-
-  locate-path@2.0.0:
-    dependencies:
-      p-locate: 2.0.0
-      path-exists: 3.0.0
-    optional: true
-
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.clonedeep@4.5.0: {}
-
-  lodash.get@4.4.2: {}
-
-  lodash.isequal@4.5.0: {}
-
   lodash.merge@4.6.2: {}
 
   lodash@4.18.1: {}
-
-  lowercase-keys@1.0.1:
-    optional: true
-
-  lru-cache@4.1.5:
-    dependencies:
-      pseudomap: 1.0.2
-      yallist: 2.1.2
-    optional: true
 
   magic-string@0.30.21:
     dependencies:
@@ -4677,26 +2298,11 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mem@1.1.0:
-    dependencies:
-      mimic-fn: 1.2.0
-    optional: true
-
-  methods@1.1.2: {}
-
   mime-db@1.52.0: {}
-
-  mime-lookup@0.0.2:
-    optional: true
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime@2.6.0: {}
-
-  mimic-fn@1.2.0:
-    optional: true
 
   minimatch@10.2.5:
     dependencies:
@@ -4712,78 +2318,13 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  native-promise-only@0.8.1: {}
-
   natural-compare@1.4.0: {}
-
-  node-fetch@1.7.3:
-    dependencies:
-      encoding: 0.1.13
-      is-stream: 1.1.0
-    optional: true
-
-  node-readfiles@0.2.0:
-    dependencies:
-      es6-promise: 3.3.1
-    optional: true
-
-  nomnom@1.5.2:
-    dependencies:
-      colors: 0.5.1
-      underscore: 1.1.7
-    optional: true
-
-  nopt@3.0.6:
-    dependencies:
-      abbrev: 1.1.1
-    optional: true
-
-  normalize-package-data@2.5.0:
-    dependencies:
-      hosted-git-info: 2.8.9
-      resolve: 1.22.12
-      semver: 5.7.2
-      validate-npm-package-license: 3.0.4
-    optional: true
-
-  npm-run-path@2.0.2:
-    dependencies:
-      path-key: 2.0.1
-    optional: true
-
-  number-is-nan@1.0.1:
-    optional: true
-
-  oauth-sign@0.9.0: {}
-
-  object-assign@2.1.1:
-    optional: true
-
-  object-assign@4.1.1:
-    optional: true
-
-  object-inspect@1.13.4: {}
-
-  object-keys@1.1.1: {}
-
-  object.assign@4.1.7:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
 
   obug@2.1.2: {}
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  ono@4.0.11:
-    dependencies:
-      format-util: 1.0.5
 
   openapi-types@12.1.3: {}
 
@@ -4796,98 +2337,29 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  os-locale@2.1.0:
-    dependencies:
-      execa: 0.7.0
-      lcid: 1.0.0
-      mem: 1.1.0
-    optional: true
-
-  own-keys@1.0.1:
-    dependencies:
-      get-intrinsic: 1.3.0
-      object-keys: 1.1.1
-      safe-push-apply: 1.0.0
-
-  p-finally@1.0.0:
-    optional: true
-
-  p-limit@1.3.0:
-    dependencies:
-      p-try: 1.0.0
-    optional: true
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-
-  p-locate@2.0.0:
-    dependencies:
-      p-limit: 1.3.0
-    optional: true
 
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
 
-  p-try@1.0.0:
-    optional: true
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parse-json@2.2.0:
-    dependencies:
-      error-ex: 1.3.4
-    optional: true
-
-  path-exists@3.0.0:
-    optional: true
 
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
-  path-key@2.0.1:
-    optional: true
-
   path-key@3.1.1: {}
 
-  path-loader@1.0.12:
-    dependencies:
-      native-promise-only: 0.8.1
-      superagent: 7.1.6
-    transitivePeerDependencies:
-      - supports-color
-
-  path-parse@1.0.7:
-    optional: true
-
-  path-to-regexp@1.9.0:
-    dependencies:
-      isarray: 0.0.1
-
-  path-type@2.0.0:
-    dependencies:
-      pify: 2.3.0
-    optional: true
-
   pathe@2.0.3: {}
-
-  performance-now@2.1.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
-
-  pify@2.3.0:
-    optional: true
-
-  pluralize@1.1.6:
-    optional: true
-
-  possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.15:
     dependencies:
@@ -4897,155 +2369,21 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prepend-http@1.0.4:
-    optional: true
-
   prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
 
   prettier@3.8.3: {}
 
-  process-nextick-args@2.0.1:
-    optional: true
-
   proxy-from-env@2.1.0: {}
-
-  pseudomap@1.0.2:
-    optional: true
-
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
 
   punycode@2.3.1: {}
 
-  q@0.9.7:
-    optional: true
-
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.5.5: {}
-
   queue-microtask@1.2.3: {}
-
-  raml-parser@0.8.18:
-    dependencies:
-      got: 2.4.0
-      jju: 1.2.1
-      json-schema-ref-parser: 3.3.1
-      object-assign: 4.1.1
-      pluralize: 1.1.6
-      q: 0.9.7
-      uritemplate: 0.3.4
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  raml-to-swagger@1.1.0:
-    dependencies:
-      http-status-codes: 1.4.0
-      json-schema-compatibility: 1.1.0
-      jsonpath: 0.2.12
-      lodash: 4.18.1
-      urijs: 1.19.11
-    optional: true
-
-  read-all-stream@1.0.2:
-    optional: true
-
-  read-pkg-up@2.0.0:
-    dependencies:
-      find-up: 2.1.0
-      read-pkg: 2.0.0
-    optional: true
-
-  read-pkg@2.0.0:
-    dependencies:
-      load-json-file: 2.0.0
-      normalize-package-data: 2.5.0
-      path-type: 2.0.0
-    optional: true
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-    optional: true
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
-  reflect.getprototypeof@1.0.10:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      which-builtin-type: 1.2.1
-
-  regexp.prototype.flags@1.5.4:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      set-function-name: 2.0.2
-
-  request@2.88.2:
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.13.2
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.5
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-
-  require-directory@2.1.1:
-    optional: true
 
   require-from-string@2.0.2: {}
 
-  require-main-filename@1.0.1:
-    optional: true
-
   resolve-from@4.0.0: {}
-
-  resolve@1.22.12:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-    optional: true
 
   reusify@1.1.0: {}
 
@@ -5078,348 +2416,37 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-array-concat@1.1.4:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      isarray: 2.0.5
-
-  safe-buffer@5.1.2:
-    optional: true
-
-  safe-buffer@5.2.1: {}
-
-  safe-push-apply@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-      isarray: 2.0.5
-
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-
-  safer-buffer@2.1.2: {}
-
-  sax@1.6.0: {}
-
-  semver@5.7.2:
-    optional: true
-
   semver@7.8.2: {}
-
-  set-blocking@2.0.0:
-    optional: true
-
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  set-function-name@2.0.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.2
-
-  set-proto@1.0.0:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-
-  shebang-command@1.2.0:
-    dependencies:
-      shebang-regex: 1.0.0
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
-  shebang-regex@1.0.0:
-    optional: true
-
   shebang-regex@3.0.0: {}
-
-  should-equal@2.0.0:
-    dependencies:
-      should-type: 1.4.0
-    optional: true
-
-  should-format@3.0.3:
-    dependencies:
-      should-type: 1.4.0
-      should-type-adaptors: 1.1.0
-    optional: true
-
-  should-type-adaptors@1.1.0:
-    dependencies:
-      should-type: 1.4.0
-      should-util: 1.0.1
-    optional: true
-
-  should-type@1.4.0:
-    optional: true
-
-  should-util@1.0.1:
-    optional: true
-
-  should@13.2.3:
-    dependencies:
-      should-equal: 2.0.0
-      should-format: 3.0.3
-      should-type: 1.4.0
-      should-type-adaptors: 1.1.0
-      should-util: 1.0.1
-    optional: true
-
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7:
-    optional: true
-
-  slash@3.0.0: {}
-
   source-map-js@1.2.1: {}
-
-  source-map@0.6.0: {}
-
-  source-map@0.6.1:
-    optional: true
-
-  spdx-correct@3.2.0:
-    dependencies:
-      spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.23
-    optional: true
-
-  spdx-exceptions@2.5.0:
-    optional: true
-
-  spdx-expression-parse@3.0.1:
-    dependencies:
-      spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.23
-    optional: true
-
-  spdx-license-ids@3.0.23:
-    optional: true
-
-  sprintf-js@1.0.3: {}
-
-  sshpk@1.18.0:
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
 
   stackback@0.0.2: {}
 
-  static-eval@0.2.3:
-    dependencies:
-      escodegen: 0.0.28
-    optional: true
-
-  static-eval@2.1.1:
-    dependencies:
-      escodegen: 2.1.0
-    optional: true
-
-  statuses@1.5.0:
-    optional: true
-
   std-env@4.1.0: {}
-
-  stop-iteration-iterator@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      internal-slot: 1.1.0
-
-  stream-shift@1.0.3:
-    optional: true
-
-  string-width@1.0.2:
-    dependencies:
-      code-point-at: 1.1.0
-      is-fullwidth-code-point: 1.0.0
-      strip-ansi: 3.0.1
-    optional: true
-
-  string-width@2.1.1:
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
-    optional: true
-
-  string.prototype.trim@1.2.11:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-data-property: 1.1.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-object-atoms: 1.1.2
-      has-property-descriptors: 1.0.2
-      safe-regex-test: 1.1.0
-
-  string.prototype.trimend@1.0.10:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-
-  string.prototype.trimstart@1.0.8:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
-    optional: true
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  strip-ansi@3.0.1:
-    dependencies:
-      ansi-regex: 2.1.1
-    optional: true
-
-  strip-ansi@4.0.0:
-    dependencies:
-      ansi-regex: 3.0.1
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-bom@3.0.0:
-    optional: true
-
-  strip-eof@1.0.0:
-    optional: true
-
   strip-json-comments@3.1.1: {}
-
-  superagent@7.1.6:
-    dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 4.4.3
-      fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
-      formidable: 2.1.5
-      methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.15.2
-      readable-stream: 3.6.2
-      semver: 7.8.2
-    transitivePeerDependencies:
-      - supports-color
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  supports-preserve-symlinks-flag@1.0.0:
-    optional: true
-
-  swagger-converter@1.5.1:
-    dependencies:
-      common-prefix: 1.1.0
-      urijs: 1.19.11
-    optional: true
-
-  swagger-methods@1.0.8: {}
-
-  swagger-schema-official@2.0.0-bab6bed: {}
-
-  swagger2openapi@2.9.4:
-    dependencies:
-      ajv: 5.5.2
-      call-me-maybe: 1.0.2
-      co: 4.6.0
-      jgexml: 0.3.9
-      js-yaml: 3.14.2
-      node-fetch: 1.7.3
-      node-readfiles: 0.2.0
-      should: 13.2.3
-      yargs: 9.0.1
-    optional: true
-
-  sway@2.0.6:
-    dependencies:
-      debug: 3.2.7
-      faker: 4.1.0
-      js-base64: 2.6.4
-      js-yaml: 3.14.2
-      json-refs: 3.0.15
-      json-schema-faker: 0.5.9
-      lodash: 4.18.1
-      native-promise-only: 0.8.1
-      path-to-regexp: 1.9.0
-      swagger-methods: 1.0.8
-      swagger-schema-official: 2.0.0-bab6bed
-      z-schema: 3.25.1
-    transitivePeerDependencies:
-      - supports-color
 
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
 
   text-table@0.2.0: {}
-
-  timed-out@2.0.0:
-    optional: true
 
   tinybench@2.9.0: {}
 
@@ -5431,17 +2458,6 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
-
-  tough-cookie@2.5.0:
-    dependencies:
-      psl: 1.15.0
-      punycode: 2.3.1
-
-  traverse@0.6.11:
-    dependencies:
-      gopd: 1.2.0
-      typedarray.prototype.slice: 1.0.5
-      which-typed-array: 1.1.22
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -5468,82 +2484,13 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  tweetnacl@0.14.5: {}
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
   type-fest@0.20.2: {}
 
-  type-of-is@3.5.1:
-    optional: true
-
-  typed-array-buffer@1.0.3:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-typed-array: 1.1.15
-
-  typed-array-byte-length@1.0.3:
-    dependencies:
-      call-bind: 1.0.9
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.15
-
-  typed-array-byte-offset@1.0.4:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.15
-      reflect.getprototypeof: 1.0.10
-
-  typed-array-length@1.0.8:
-    dependencies:
-      call-bind: 1.0.9
-      for-each: 0.3.5
-      gopd: 1.2.0
-      is-typed-array: 1.1.15
-      possible-typed-array-names: 1.1.0
-      reflect.getprototypeof: 1.0.10
-
-  typedarray.prototype.slice@1.0.5:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      get-proto: 1.0.1
-      math-intrinsics: 1.1.0
-      typed-array-buffer: 1.0.3
-      typed-array-byte-offset: 1.0.4
-
   typescript@5.9.3: {}
-
-  unbox-primitive@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-bigints: 1.1.0
-      has-symbols: 1.1.0
-      which-boxed-primitive: 1.1.1
-
-  underscore@1.1.7:
-    optional: true
-
-  underscore@1.13.6:
-    optional: true
-
-  underscore@1.7.0:
-    optional: true
 
   undici-types@6.21.0: {}
 
@@ -5551,30 +2498,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  urijs@1.19.11: {}
-
-  uritemplate@0.3.4:
-    optional: true
-
-  util-deprecate@1.0.2: {}
-
-  uuid@3.4.0: {}
-
   v8-compile-cache-lib@3.0.1: {}
-
-  validate-npm-package-license@3.0.4:
-    dependencies:
-      spdx-correct: 3.2.0
-      spdx-expression-parse: 3.0.1
-    optional: true
-
-  validator@10.11.0: {}
-
-  verror@1.10.0:
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
 
   vite@8.0.16(@types/node@22.19.19):
     dependencies:
@@ -5614,55 +2538,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  which-boxed-primitive@1.1.1:
-    dependencies:
-      is-bigint: 1.1.0
-      is-boolean-object: 1.2.2
-      is-number-object: 1.1.1
-      is-string: 1.1.1
-      is-symbol: 1.1.1
-
-  which-builtin-type@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      function.prototype.name: 1.1.8
-      has-tostringtag: 1.0.2
-      is-async-function: 2.1.1
-      is-date-object: 1.1.0
-      is-finalizationregistry: 1.1.1
-      is-generator-function: 1.1.2
-      is-regex: 1.2.1
-      is-weakref: 1.1.1
-      isarray: 2.0.5
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.22
-
-  which-collection@1.0.2:
-    dependencies:
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-weakmap: 2.0.2
-      is-weakset: 2.0.4
-
-  which-module@2.0.1:
-    optional: true
-
-  which-typed-array@1.1.22:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-
-  which@1.3.1:
-    dependencies:
-      isexe: 2.0.0
-    optional: true
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5674,58 +2549,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrap-ansi@2.1.0:
-    dependencies:
-      string-width: 1.0.2
-      strip-ansi: 3.0.1
-    optional: true
-
   wrappy@1.0.2: {}
-
-  xml2js@0.4.23:
-    dependencies:
-      sax: 1.6.0
-      xmlbuilder: 11.0.1
-
-  xmlbuilder@11.0.1: {}
-
-  y18n@3.2.2:
-    optional: true
-
-  yallist@2.1.2:
-    optional: true
-
-  yargs-parser@7.0.0:
-    dependencies:
-      camelcase: 4.1.0
-    optional: true
-
-  yargs@9.0.1:
-    dependencies:
-      camelcase: 4.1.0
-      cliui: 3.2.0
-      decamelize: 1.2.0
-      get-caller-file: 1.0.3
-      os-locale: 2.1.0
-      read-pkg-up: 2.0.0
-      require-directory: 2.1.1
-      require-main-filename: 1.0.1
-      set-blocking: 2.0.0
-      string-width: 2.1.1
-      which-module: 2.0.1
-      y18n: 3.2.2
-      yargs-parser: 7.0.0
-    optional: true
 
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
-
-  z-schema@3.25.1:
-    dependencies:
-      core-js: 2.6.12
-      lodash.get: 4.4.2
-      lodash.isequal: 4.5.0
-      validator: 10.11.0
-    optionalDependencies:
-      commander: 2.20.3

--- a/src/CodeGen.ts
+++ b/src/CodeGen.ts
@@ -6,6 +6,7 @@ import { OpenAPIV2, IJsonSchema } from 'openapi-types'
 import Mustache from 'mustache'
 import _ from 'lodash'
 import axios from 'axios'
+import { convertOpenApi3ToSwagger2 } from './openapi'
 
 export interface GenConfig {
   /**
@@ -256,14 +257,7 @@ export class CodeGen {
       fs.writeFileSync(outputPath, JSON.stringify(apiDocsJson, undefined, 2), fileOptions)
 
       if (docVersion.startsWith('3.')) {
-        const ApiSpecConverter = require('api-spec-converter')
-        const converted = await ApiSpecConverter.convert({
-          from: 'openapi_3',
-          to: 'swagger_2',
-          source: outputPath,
-        })
-        const swagger2Json = converted.stringify()
-        fs.writeFileSync(outputPath, JSON.stringify(JSON.parse(swagger2Json), undefined, 2), fileOptions)
+        fs.writeFileSync(outputPath, JSON.stringify(convertOpenApi3ToSwagger2(apiDocsJson), undefined, 2), fileOptions)
       }
 
       const doc = await SwaggerParser.parse(outputPath)

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,0 +1,93 @@
+type JsonObject = Record<string, any>
+
+function rewriteRef(value: string) {
+  return value.replace('#/components/schemas/', '#/definitions/')
+}
+
+function convertRefs<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => convertRefs(item)) as T
+  }
+
+  if (value && typeof value === 'object') {
+    const result: JsonObject = {}
+    for (const [key, item] of Object.entries(value as JsonObject)) {
+      result[key] = key === '$ref' && typeof item === 'string' ? rewriteRef(item) : convertRefs(item)
+    }
+    return result as T
+  }
+
+  return value
+}
+
+function pickJsonSchema(content?: JsonObject) {
+  if (!content) {
+    return undefined
+  }
+
+  return (content['application/json'] || content['*/*'] || Object.values(content)[0])?.schema
+}
+
+function convertParameters(operation: JsonObject) {
+  const parameters = [...(operation.parameters || [])].map((parameter) => {
+    const convertedParameter = convertRefs(parameter) as JsonObject
+    if (convertedParameter.schema) {
+      Object.assign(convertedParameter, convertRefs(convertedParameter.schema))
+      delete convertedParameter.schema
+    }
+    return convertedParameter
+  })
+  const schema = pickJsonSchema(operation.requestBody?.content)
+  if (schema) {
+    parameters.push({
+      name: 'body',
+      in: 'body',
+      required: !!operation.requestBody?.required,
+      schema: convertRefs(schema),
+    })
+  }
+  return parameters
+}
+
+function convertResponses(responses: JsonObject = {}) {
+  const result: JsonObject = {}
+  for (const [status, response] of Object.entries(responses)) {
+    const responseObject = convertRefs(response) as JsonObject
+    const schema = pickJsonSchema(responseObject.content)
+    if (schema) {
+      responseObject.schema = convertRefs(schema)
+    }
+    delete responseObject.content
+    result[status] = responseObject
+  }
+  return result
+}
+
+export function convertOpenApi3ToSwagger2(doc: JsonObject) {
+  const paths: JsonObject = {}
+  for (const [apiPath, pathItem] of Object.entries(doc.paths || {})) {
+    const convertedPathItem: JsonObject = {}
+    for (const [key, value] of Object.entries(pathItem as JsonObject)) {
+      if (!value || typeof value !== 'object' || !('responses' in value)) {
+        convertedPathItem[key] = convertRefs(value)
+        continue
+      }
+
+      const operation = value as JsonObject
+      convertedPathItem[key] = {
+        ...convertRefs(operation),
+        parameters: convertParameters(operation),
+        responses: convertResponses(operation.responses),
+      }
+      delete convertedPathItem[key].requestBody
+    }
+    paths[apiPath] = convertedPathItem
+  }
+
+  return {
+    ...doc,
+    swagger: '2.0',
+    paths,
+    definitions: convertRefs(doc.components?.schemas || {}),
+  }
+}

--- a/src/typings/api-spec-converter.d.ts
+++ b/src/typings/api-spec-converter.d.ts
@@ -1,7 +1,0 @@
-declare module 'api-spec-converter' {
-  const ApiSpecConverter: {
-    convert: (options: { from: string; to: string; source: string }) => any
-  }
-
-  export = ApiSpecConverter
-}

--- a/test/CodeGen.test.ts
+++ b/test/CodeGen.test.ts
@@ -108,4 +108,113 @@ describe('CodeGen', () => {
     expect(resultText).toContain('export interface Result<T>')
     expect(resultText).toContain('data?: T')
   })
+
+  it('generates apis and models from an OpenAPI 3 file', async () => {
+    const tempDir = createTempDir()
+    const docPath = path.join(tempDir, 'openapi.json')
+    const outputDir = path.join(tempDir, 'output')
+
+    fs.writeFileSync(
+      docPath,
+      JSON.stringify({
+        openapi: '3.0.1',
+        info: {
+          title: 'Role API',
+          version: '1.0.0',
+        },
+        paths: {
+          '/sys/role/list': {
+            post: {
+              summary: 'List roles',
+              parameters: [
+                {
+                  name: 'pageNo',
+                  in: 'query',
+                  schema: {
+                    type: 'integer',
+                  },
+                },
+              ],
+              requestBody: {
+                required: true,
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/RoleQuery',
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        $ref: '#/components/schemas/RolePage',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            RoleQuery: {
+              type: 'object',
+              required: ['name'],
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+            RolePage: {
+              type: 'object',
+              properties: {
+                records: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/Role',
+                  },
+                },
+              },
+            },
+            Role: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'integer',
+                },
+              },
+            },
+          },
+        },
+      }),
+    )
+
+    await CodeGen.create({
+      docUrl: docPath,
+      docVersion: '3.0.1',
+      baseName: '',
+      baseUrl: '/api',
+      templateDir: path.join(process.cwd(), 'template'),
+      outputDir,
+      paths: ['/sys/role/list'],
+      excludePaths: ['exportXls'],
+      apiCut: [],
+      pathReplace: [],
+    }).gen()
+
+    const apiText = fs.readFileSync(path.join(outputDir, 'role.ts'), 'utf-8')
+    const rolePageText = fs.readFileSync(path.join(outputDir, 'models', 'RolePage.ts'), 'utf-8')
+
+    expect(apiText).toContain('export function api_sys_role_list')
+    expect(apiText).toContain('params?: models.SysRoleListPostParams')
+    expect(apiText).toContain('data: models.RoleQuery')
+    expect(apiText).toContain('post<models.RolePage>')
+    expect(rolePageText).toContain('records?: Array<models.Role>')
+  })
 })


### PR DESCRIPTION
## 变更
- 移除触发 DEP0169 的 api-spec-converter 旧转换链路
- 增加轻量 OpenAPI 3 到 Swagger 2 转换，覆盖 parameters、requestBody、responses、components.schemas 引用改写
- 补充 OpenAPI 3 生成回归测试，覆盖 /sys/role/list 类似场景

## 验证
- NODE_OPTIONS=--trace-deprecation pnpm test
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm pack --pack-destination /tmp
- pnpm install --frozen-lockfile
- git diff --check

Closes AB-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)