### PR TITLE
AB-24: 调整 npm 发布触发流程

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,30 @@
 name: Publish
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to publish, for example v1.5.0
+        required: true
+        type: string
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG_NAME }}
       - uses: pnpm/action-setup@v4
         with:
           version: 10.34.1
@@ -27,3 +37,15 @@ jobs:
       - run: pnpm test
       - run: pnpm build
       - run: npm publish --provenance --access public --registry=https://registry.npmjs.org/
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${TAG_NAME}" > /dev/null 2>&1; then
+            echo "GitHub Release ${TAG_NAME} already exists."
+            exit 0
+          fi
+
+          gh release create "${TAG_NAME}" \
+            --title "${TAG_NAME}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ pnpm build
 
 ## Release
 
-Publishing is handled by GitHub Actions with npm Trusted Publisher. Create a GitHub Release after npm has trusted publishing configured for this repository.
+Publishing is handled by GitHub Actions with npm Trusted Publisher. Push a version tag like `v1.5.0`, or run the Publish workflow manually with a tag input. The workflow publishes to npm first, then creates the GitHub Release after npm publish succeeds.


### PR DESCRIPTION
## Summary
- 改为 tag push 触发 npm 发布，并支持 workflow_dispatch 手动触发
- npm publish 成功后再通过 GitHub CLI 创建 Release
- 更新 README 发布说明

## Tests
- pnpm exec prettier --check .github/workflows/publish.yml README.md
- git diff --check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
